### PR TITLE
Benchmarking BBS+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +88,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -120,7 +141,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -179,12 +200,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -199,10 +214,10 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "bn254_hash2curve",
- "crypto-bigint 0.5.2",
- "digest 0.10.7",
- "elliptic-curve 0.13.5",
- "hash2field",
+ "criterion",
+ "crypto-bigint",
+ "digest",
+ "elliptic-curve",
  "hex",
  "hkdf",
  "num-bigint",
@@ -234,8 +249,8 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
- "digest 0.10.7",
- "elliptic-curve 0.13.5",
+ "digest",
+ "elliptic-curve",
  "hex",
  "num-bigint",
  "num-integer",
@@ -244,10 +259,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -262,10 +289,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "const-oid"
-version = "0.7.1"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cpufeatures"
@@ -277,16 +350,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.3.2"
+name = "criterion"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -311,15 +439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid",
-]
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,15 +447,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -358,45 +468,18 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.3.2",
- "der",
- "ff 0.11.1",
- "generic-array",
- "group 0.11.0",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.2",
- "ff 0.13.0",
+ "base16ct",
+ "crypto-bigint",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "rand_core",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
-dependencies = [
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -439,35 +522,23 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
-dependencies = [
- "ff 0.11.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
-name = "hash2field"
-version = "0.4.0"
+name = "half"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60f910ea7294fe98e69db0b18c2991c9205d7020b4bf8174905f91bb70e7cf2"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "digest 0.9.0",
- "elliptic-curve 0.11.12",
- "subtle",
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -478,6 +549,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -500,7 +577,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -513,10 +601,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -579,6 +688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +704,34 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -645,6 +788,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,10 +852,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+
+[[package]]
+name = "serde"
+version = "1.0.208"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.208"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha2"
@@ -673,7 +912,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -771,6 +1010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,10 +1049,176 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,11 @@ harness = false
 [[bench]]
 name = "verify"
 harness = false
+
+[[bench]]
+name = "proof_gen"
+harness = false
+
+[[bench]]
+name = "proof_verify"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ hkdf = "0.12.3"
 crypto-bigint = "0.5.2"
 ark-ff = "0.4.2"
 num-bigint = "0.4.3"
-hash2field = "0.4.0"
 hex = "0.4.3"
 num-integer = "0.1.45"
 elliptic-curve = "0.13.5"
@@ -28,3 +27,18 @@ ark-serialize = "0.4.2"
 test-case = "3.3.1"
 once_cell = "1.10.0"
 thiserror = "1.0.63"
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "keygen"
+harness = false
+
+[[bench]]
+name = "sign"
+harness = false
+
+[[bench]]
+name = "verify"
+harness = false

--- a/README.md
+++ b/README.md
@@ -76,9 +76,19 @@ To run all the benchmarks:
 ```rust
 cargo bench
 ```
-You can also run specific benchmarks using `--bench` flag.
+Running entire benchmark will take some significant time! You can also run specific benchmarks using `--bench` flag.
 ```rust
 cargo bench --bench <benchmark_target>
 ```
-The following benchmark targets are availabe: `keygen`, `sign`, `verify`(e.g., `cargo bench --bench keygen`).
-The sign and verify benchmark targets contains two benchmark function, one on single message of varying length and another on variable number of messages each of length 32bytes.
+The following benchmark targets are availabe: `keygen`, `sign`, `verify`, `proof_gen` and `proof_verify`(e.g., `cargo bench --bench keygen`).
+
+The benchmarks evaluate the following different scenarios:
+- `keygen`: 
+    - varying length of `key_material`
+- `sign` and `verify`: 
+    - single message with varying message lengths 
+    - multiple messages each of a fixed length(32 bytes)
+- `proof_gen` and `proof_verify`: 
+    - single message with varying message lengths with no disclosed indices
+    - multiple messages each of a fixed length(32 bytes) with no disclosed indices 
+    - multiple messages each of a fixed length(32 bytes) with varying disclosed indices

--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ fn main() {
     assert!(proof_verify(pk, proof, &[], &[], disclosed_msgs.as_slice(), disclosed_indices.as_slice()).unwrap());
 }
 ```
+## Benchmarking with Criterion
+
+benchmarking for the BBS+ signature scheme is done using [Criterion.rs](https://github.com/bheisler/criterion.rs), a powerful framework for benchmarking Rust code. The benchmarks cover the key generation, message signing, and signature verification processes.
+
+To run all the benchmarks:
+```rust
+cargo bench
+```
+You can also run specific benchmarks using `--bench` flag.
+```rust
+cargo bench --bench <benchmark_target>
+```
+The following benchmark targets are availabe: `keygen`, `sign`, `verify`(e.g., `cargo bench --bench keygen`).
+The sign and verify benchmark targets contains two benchmark function, one on single message of varying length and another on variable number of messages each of length 32bytes.

--- a/benches/keygen.rs
+++ b/benches/keygen.rs
@@ -1,0 +1,31 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use bbs_plus::key_gen::SecretKey;
+use rand::Rng;
+
+
+pub fn keygen_benchmark(c: &mut Criterion) {
+
+    let mut group = c.benchmark_group("keygen");
+
+    for size in [32, 64, 128, 256, 512, 1024].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        // generating random key_material and key_info
+        let mut rng = rand::thread_rng();
+        let mut key_material: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect();
+        let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+        let key_info: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect();
+
+        b.iter(|| SecretKey::key_gen(black_box(&mut key_material), black_box(&key_info), black_box(key_dst)));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, keygen_benchmark);
+criterion_main!(benches);
+

--- a/benches/proof_gen.rs
+++ b/benches/proof_gen.rs
@@ -1,0 +1,118 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+use bbs_plus::proof_gen::proof_gen;
+
+// benchmarking proof generation on single message with varying message length
+pub fn proof_gen_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_gen_single_msg");
+
+    // message size
+    for size in [32, 64, 128, 256, 512, 1024, 2048].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+        let signature = sk.sign(&[&msg], &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(&[&msg])).unwrap());
+
+        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],&[&msg], &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof generation on multiple messages each of length 32bytes
+pub fn proof_gen_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_gen_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        let signature = sk.sign(msgs, &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+
+        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],msgs, &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof generation on multiple disclosed indices with each msg of length 32bytes
+pub fn proof_gen_benchmark_multiple_disclosed_indices(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    // random msgs of length 32 each msg of length 32
+    let random_msgs_vecs: Vec<Vec<u8>> = (0..32)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+    
+    let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+    let msgs: &[&[u8]] = &msg_slices;
+    
+    let signature = sk.sign(msgs, &[]).unwrap();
+    assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+
+    let mut group = c.benchmark_group("proof_gen_multiple_disclosed_indices");
+
+    // indices
+    for indices in [1, 2, 4, 8, 16, 32].iter() {
+
+        group.throughput(Throughput::Bytes(*indices as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(indices), indices, |b, &indices| {
+        
+        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],msgs, (0..indices).collect::<Vec<_>>().as_slice()));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = proof_gen_benchmark_single_msg, proof_gen_benchmark_multiple_msgs, proof_gen_benchmark_multiple_disclosed_indices
+}
+criterion_main!(benches);
+

--- a/benches/proof_verify.rs
+++ b/benches/proof_verify.rs
@@ -1,0 +1,125 @@
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+use bbs_plus::proof_gen::proof_gen;
+use bbs_plus::proof_verify::proof_verify;
+
+// benchmarking proof verification on single message with varying message length
+pub fn proof_verify_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_verify_single_msg");
+
+    // message size
+    for size in [32, 64, 128, 256, 512, 1024, 2048].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+        let signature = sk.sign(&[&msg], &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(&[&msg])).unwrap());
+        let proof = proof_gen(pk.clone(), signature, &[], &[],&[&msg], &[]).unwrap();
+
+        b.iter(|| proof_verify(pk.clone(), proof.clone(), &[], &[], &[&[]], &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof verification on multiple messages each of length 32bytes
+pub fn proof_verify_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_verify_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        let signature = sk.sign(msgs, &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+        let proof = proof_gen(pk.clone(), signature, &[], &[],msgs, &[]).unwrap();
+        
+        b.iter(|| proof_verify(pk.clone(), proof.clone(), &[], &[], &[&[]], &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof verification on multiple disclosed indices with each msg of length 32bytes
+pub fn proof_verify_benchmark_multiple_disclosed_indices(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    // random msgs of length 32 each msg of length 32
+    let random_msgs_vecs: Vec<Vec<u8>> = (0..32)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+    
+    let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+    let msgs: &[&[u8]] = &msg_slices;
+    
+    let signature = sk.sign(msgs, &[]).unwrap();
+    assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+
+    let mut group = c.benchmark_group("proof_verify_multiple_disclosed_indices");
+
+    // indices
+    for indices in [1, 2, 4, 8, 16, 32].iter() {
+
+        group.throughput(Throughput::Bytes(*indices as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(indices), indices, |b, &indices| {
+        
+        let disclosed_indices = (0..indices).collect::<Vec<_>>();
+        let disclosed_msgs = disclosed_indices.iter().map(|i| msgs[*i]).collect::<Vec<_>>();
+        let proof = proof_gen(pk.clone(), signature, &[], &[],msgs, disclosed_indices.as_slice()).unwrap();
+        b.iter(|| proof_verify(pk.clone(), proof.clone(), &[], &[], &disclosed_msgs, &disclosed_indices));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = proof_verify_benchmark_single_msg, proof_verify_benchmark_multiple_msgs, proof_verify_benchmark_multiple_disclosed_indices
+}
+criterion_main!(benches);
+

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -1,0 +1,71 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+
+// benchmarking signing on single message with varying message length
+pub fn sign_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+
+    let mut group = c.benchmark_group("sign_single_msg");
+
+    // message size
+    for size in [128, 256, 512, 1024, 2048, 4096].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+
+        b.iter(|| sk.sign(black_box(&[&msg]), &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking signing on multiple messages each of length 32bytes
+pub fn sign_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+
+    let mut group = c.benchmark_group("sign_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        b.iter(|| sk.sign(black_box(msgs), &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = sign_benchmark_single_msg, sign_benchmark_multiple_msgs
+}
+criterion_main!(benches);
+

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -12,7 +12,7 @@ pub fn sign_benchmark_single_msg(c: &mut Criterion) {
     let mut group = c.benchmark_group("sign_single_msg");
 
     // message size
-    for size in [128, 256, 512, 1024, 2048, 4096].iter() {
+    for size in [32, 64, 128, 256, 512, 1024, 2048].iter() {
 
         group.throughput(Throughput::Bytes(*size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {

--- a/benches/verify.rs
+++ b/benches/verify.rs
@@ -1,0 +1,76 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+
+// benchmarking signature verification on single message with varying message length
+pub fn verify_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("verify_single_msg");
+
+    // message size
+    for size in [128, 256, 512, 1024, 2048, 4096].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+        let signature = sk.sign(&[&msg], &[]).unwrap();
+
+        b.iter(|| pk.verify(signature, &[], black_box(&[&msg])));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking signature verification on multiple messages each of length 32bytes
+pub fn verify_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("verify_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        let signature = sk.sign(msgs, &[]).unwrap();
+
+        b.iter(|| pk.verify(signature, &[], black_box(msgs)));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = verify_benchmark_single_msg, verify_benchmark_multiple_msgs
+}
+criterion_main!(benches);
+

--- a/src/tests/proof_verify_tests.rs
+++ b/src/tests/proof_verify_tests.rs
@@ -33,8 +33,11 @@ mod tests {
         random_vecs
     }
 
+    // happy path
+    #[test_case(0, vec![], b"")]
     #[test_case(0, vec![], b"abc")]
     #[test_case(1, vec![0], b"abc")]
+    #[test_case(1, vec![], b"abc")]
     #[test_case(10, vec![0,1,2], b"")]
     #[test_case(10, vec![0,4,7,9], b"def")]
     #[test_case(5, vec![0,4], b"defghjsdjdbcjbejd")]


### PR DESCRIPTION
This PR includes benchmarking code for the following:
- keygen
- sign
- verify
- proof_gen
- proof_verify

The following different scenarios is considered for benchmarking:
- keygen: varying length of key_material
- sign and verify: single message with varying message lengths and multiple messages each of a fixed length(32 bytes)
- proof_gen and proof_verify: single message with varying message lengths with no disclosed indices, multiple messages each of a fixed length(32 bytes) with no disclosed indices and multiple messages each of a fixed length(32 bytes) with varying disclosed indices.