### PR TITLE
Generic Implementation to support both BN254 and BLS12-381 curve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +88,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -120,7 +141,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -179,12 +200,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
-name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -199,10 +214,10 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "bn254_hash2curve",
- "crypto-bigint 0.5.2",
- "digest 0.10.7",
- "elliptic-curve 0.13.5",
- "hash2field",
+ "criterion",
+ "crypto-bigint",
+ "digest",
+ "elliptic-curve",
  "hex",
  "hkdf",
  "num-bigint",
@@ -234,8 +249,8 @@ dependencies = [
  "ark-bn254",
  "ark-ec",
  "ark-ff",
- "digest 0.10.7",
- "elliptic-curve 0.13.5",
+ "digest",
+ "elliptic-curve",
  "hex",
  "num-bigint",
  "num-integer",
@@ -244,10 +259,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -262,10 +289,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "const-oid"
-version = "0.7.1"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cpufeatures"
@@ -277,16 +350,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.3.2"
+name = "criterion"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -311,15 +439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid",
-]
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,15 +447,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -358,45 +468,18 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.3.2",
- "der",
- "ff 0.11.1",
- "generic-array",
- "group 0.11.0",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.2",
- "ff 0.13.0",
+ "base16ct",
+ "crypto-bigint",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "rand_core",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
-dependencies = [
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -439,35 +522,23 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
-dependencies = [
- "ff 0.11.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
-name = "hash2field"
-version = "0.4.0"
+name = "half"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60f910ea7294fe98e69db0b18c2991c9205d7020b4bf8174905f91bb70e7cf2"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
- "digest 0.9.0",
- "elliptic-curve 0.11.12",
- "subtle",
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -478,6 +549,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -500,7 +577,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -513,10 +601,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -579,6 +688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +704,34 @@ name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "plotters"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -645,6 +788,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,10 +852,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+
+[[package]]
+name = "serde"
+version = "1.0.208"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.208"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha2"
@@ -673,7 +912,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -771,6 +1010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,10 +1049,176 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +220,7 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 name = "bbs_plus"
 version = "0.1.0"
 dependencies = [
+ "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "ark-std",
+ "bls12_381",
  "bn254_hash2curve",
  "criterion",
  "crypto-bigint",
@@ -246,6 +247,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,9 +268,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/zkcrypto/bls12_381.git?rev=9ea427c0eb1a7e2ac16902a322aea156c496ddb0#9ea427c0eb1a7e2ac16902a322aea156c496ddb0"
+dependencies = [
+ "digest",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "bn254_hash2curve"
-version = "0.1.0"
-source = "git+https://github.com/hashcloak/bn254-hash-to-curve.git#5a0934ce9195b7ebd7b82409526027b117728ff1"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5d0f1b88e622de99ca8764a3b0730bb318474fada7aad15653a7398c97a6d16"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -501,9 +528,16 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -707,6 +741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +812,12 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -968,6 +1017,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "test-case"
@@ -1232,6 +1287,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,26 +27,27 @@ ark-serialize = "0.4.2"
 test-case = "3.3.1"
 once_cell = "1.10.0"
 thiserror = "1.0.63"
+ark-bls12-381 = "0.4.0"
 
 [dev-dependencies]
 criterion = "0.5.1"
 
-[[bench]]
-name = "keygen"
-harness = false
+# [[bench]]
+# name = "keygen"
+# harness = false
 
-[[bench]]
-name = "sign"
-harness = false
+# [[bench]]
+# name = "sign"
+# harness = false
 
-[[bench]]
-name = "verify"
-harness = false
+# [[bench]]
+# name = "verify"
+# harness = false
 
-[[bench]]
-name = "proof_gen"
-harness = false
+# [[bench]]
+# name = "proof_gen"
+# harness = false
 
-[[bench]]
-name = "proof_verify"
-harness = false
+# [[bench]]
+# name = "proof_verify"
+# harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,11 @@ harness = false
 [[bench]]
 name = "verify"
 harness = false
+
+[[bench]]
+name = "proof_gen"
+harness = false
+
+[[bench]]
+name = "proof_verify"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ criterion = "0.5.1"
 name = "keygen"
 harness = false
 
-# [[bench]]
-# name = "sign"
-# harness = false
+[[bench]]
+name = "sign"
+harness = false
 
-# [[bench]]
-# name = "verify"
-# harness = false
+[[bench]]
+name = "verify"
+harness = false
 
 # [[bench]]
 # name = "proof_gen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ ark-bls12-381 = "0.4.0"
 [dev-dependencies]
 criterion = "0.5.1"
 
-# [[bench]]
-# name = "keygen"
-# harness = false
+[[bench]]
+name = "keygen"
+harness = false
 
 # [[bench]]
 # name = "sign"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,14 @@ elliptic-curve = "0.13.5"
 subtle = "2.5.0"
 ark-ec = "0.4.2"
 ark-std = "0.4.0"
-bn254_hash2curve ={ git = "https://github.com/hashcloak/bn254-hash-to-curve.git", features = ["gnark_crypto_compatible"]}
+bn254_hash2curve ={ version = "0.1.1"}
 zeroize = "1.8.1"
 ark-serialize = "0.4.2"
 test-case = "3.3.1"
 once_cell = "1.10.0"
 thiserror = "1.0.63"
 ark-bls12-381 = "0.4.0"
+bls12_381 = {git = "https://github.com/zkcrypto/bls12_381.git", rev = "9ea427c0eb1a7e2ac16902a322aea156c496ddb0", features = ["experimental"]} # for hashing to G1
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ harness = false
 name = "verify"
 harness = false
 
-# [[bench]]
-# name = "proof_gen"
-# harness = false
+[[bench]]
+name = "proof_gen"
+harness = false
 
-# [[bench]]
-# name = "proof_verify"
-# harness = false
+[[bench]]
+name = "proof_verify"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ hkdf = "0.12.3"
 crypto-bigint = "0.5.2"
 ark-ff = "0.4.2"
 num-bigint = "0.4.3"
-hash2field = "0.4.0"
 hex = "0.4.3"
 num-integer = "0.1.45"
 elliptic-curve = "0.13.5"
@@ -28,3 +27,18 @@ ark-serialize = "0.4.2"
 test-case = "3.3.1"
 once_cell = "1.10.0"
 thiserror = "1.0.63"
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "keygen"
+harness = false
+
+[[bench]]
+name = "sign"
+harness = false
+
+[[bench]]
+name = "verify"
+harness = false

--- a/README.md
+++ b/README.md
@@ -76,9 +76,19 @@ To run all the benchmarks:
 ```rust
 cargo bench
 ```
-You can also run specific benchmarks using `--bench` flag.
+Running entire benchmark will take some significant time! You can also run specific benchmarks using `--bench` flag.
 ```rust
 cargo bench --bench <benchmark_target>
 ```
-The following benchmark targets are availabe: `keygen`, `sign`, `verify`(e.g., `cargo bench --bench keygen`).
-The sign and verify benchmark targets contains two benchmark function, one on single message of varying length and another on variable number of messages each of length 32bytes.
+The following benchmark targets are availabe: `keygen`, `sign`, `verify`, `proof_gen` and `proof_verify`(e.g., `cargo bench --bench keygen`).
+
+The benchmarks evaluate the following different scenarios:
+- `keygen`: 
+    - varying length of `key_material`
+- `sign` and `verify`: 
+    - single message with varying message lengths 
+    - multiple messages each of a fixed length(32 bytes)
+- `proof_gen` and `proof_verify`: 
+    - single message with varying message lengths with no disclosed indices
+    - multiple messages each of a fixed length(32 bytes) with no disclosed indices 
+    - multiple messages each of a fixed length(32 bytes) with varying disclosed indices

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BBS+ Signature Scheme over BN254 Pairing
+# BBS+ Signature Scheme over BN254 & BLS12-381 Pairing
 
 ## Warning!!!
 
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This repository implements the BBS+ signature scheme over the BN254 elliptic curve pairing. BBS+ is a cryptographic scheme that supports efficient multi-message signing, selective disclosure, and proof of knowledge, making it suitable for privacy-preserving applications such as anonymous credentials and digital signatures.
+This repository implements the BBS+ signature scheme supporting over both the BN254(arkworks) and BLS12381(arkworks) pairing curve. BBS+ is a cryptographic scheme that supports efficient multi-message signing, selective disclosure, and proof of knowledge, making it suitable for privacy-preserving applications such as anonymous credentials and digital signatures.
 
 The implementation follows the specifications outlined in the [IETF draft for BBS signatures](https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html) and leverages the BN254 pairing-friendly curve for cryptographic operations.
 
@@ -20,40 +20,54 @@ The implementation follows the specifications outlined in the [IETF draft for BB
 
 ## Usage
 
-Add this library under dependencies in the Cargo.toml of your project:
+Add the following library under dependencies in the Cargo.toml of your project:
 ```rust
 [dependencies]
 bbs_plus ={ git = "https://github.com/hashcloak/bbs_sign.git"}
+ark-bn254 = "0.4.0" # For BBS over BN254
+ark-bls12-381 = "0.4.0" # For BBS over BLS12-381
 ```
-and then use as shown below for key-gen, signing and verifying(both full and selectively disclosed msg)
+and then use as shown below for key-gen, signing and verifying, proof generation and verification(both full and selectively disclosed msg)
 
 ```rust
-use bbs_plus::key_gen::SecretKey;
-use bbs_plus::proof_gen::proof_gen;
-use bbs_plus::proof_verify::proof_verify;
+use bbs_plus::{
+    key_gen::{SecretKey, PublicKey},
+    proof_gen::proof_gen,
+    proof_verify::proof_verify,
+    constants::{
+        Bn254Const, // For BBS over BN254
+        Bls12381Const   // For BBS over BLS12-381
+    },
+    utils::interface_utilities::{ 
+        HashToG1Bn254,  // For BBS over BN254
+        HashToG1Bls12381    // For BBS over BLS12-381
+    },
+};
+use ark_bn254::{Bn254, Fr as FrBn254};  // For BBS over BN254
+use ark_bls12_381::{Bls12_381, Fr as FrBls12381};    // For BBS over BLS12-381
 
 fn main() {
     
+    // ----------------------------BBS over BN254------------------------------------- 
+    
+    // ensure that key_meterial is at least 32 bytes, otherwise it will panic
     let mut key_material = [5u8; 32];
     let key_dst = b"BBS-SIG-KEYGEN-SALT-";
 
-    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst);
-    assert!(sk.is_ok());
-
     // secret and public key
-    let sk = sk.unwrap();
-    let pk = sk.sk_to_pk();
+    let sk: SecretKey<FrBn254> = SecretKey::<FrBn254>::key_gen::<Bn254>(&mut key_material, &[], key_dst.as_slice()).unwrap();
+    let pk: PublicKey<Bn254> = sk.sk_to_pk();
 
     let msgs: &[&[u8]] = &[b"message1", b"message2", b"msg3", b"msg4"];
 
     // signature
-    let sig = sk.sign(msgs, &[]);
+    let sig = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(msgs, &[]);
     assert!(sig.is_ok());
 
     let sig = sig.unwrap();
 
     // verify
-    let res = pk.clone().verify(sig, &[], msgs);
+    let res = pk.clone().verify::<FrBn254, HashToG1Bn254, Bn254Const>(sig, &[], msgs);
     assert!(res.is_ok());
     assert!(res.unwrap());
 
@@ -61,16 +75,52 @@ fn main() {
     let disclosed_indices = [0, 2];
     let disclosed_msgs = [msgs[0], msgs[2]];
 
-    let proof = proof_gen(pk.clone(), sig, &[], &[], msgs, disclosed_indices.as_slice());
+    let proof = proof_gen::<Bn254, FrBn254, HashToG1Bn254, Bn254Const>(pk.clone(), sig, &[], &[], msgs, disclosed_indices.as_slice());
     assert!(proof.is_ok());
     let proof = proof.unwrap();
 
-    assert!(proof_verify(pk, proof, &[], &[], disclosed_msgs.as_slice(), disclosed_indices.as_slice()).unwrap());
+    assert!(proof_verify::<Bn254, FrBn254, HashToG1Bn254, Bn254Const>(pk, proof, &[], &[], disclosed_msgs.as_slice(), disclosed_indices.as_slice()).unwrap());
+
+
+    // ----------------------------BBS over BLS12-381------------------------------------- 
+
+    // ensure that key_meterial is at least 32 bytes, otherwise it will panic
+    let mut key_material = [5u8; 32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+
+    // secret and public key
+    let sk: SecretKey<FrBls12381> = SecretKey::<FrBls12381>::key_gen::<Bls12_381>(&mut key_material, &[], key_dst.as_slice()).unwrap();
+    let pk: PublicKey<Bls12_381> = sk.sk_to_pk();
+
+    let msgs: &[&[u8]] = &[b"message1", b"message2", b"msg3", b"msg4"];
+
+    // signature
+    let sig = sk.sign::<Bls12_381, Bls12381Const, HashToG1Bls12381>(msgs, &[]);
+    assert!(sig.is_ok());
+
+    let sig = sig.unwrap();
+
+    // verify
+    let res = pk.clone().verify::<FrBls12381, HashToG1Bls12381, Bls12381Const>(sig, &[], msgs);
+    assert!(res.is_ok());
+    assert!(res.unwrap());
+
+    // disclose specific messages
+    let disclosed_indices = [0, 2];
+    let disclosed_msgs = [msgs[0], msgs[2]];
+
+    let proof = proof_gen::<Bls12_381, FrBls12381, HashToG1Bls12381, Bls12381Const>(pk.clone(), sig, &[], &[], msgs, disclosed_indices.as_slice());
+    assert!(proof.is_ok());
+    let proof = proof.unwrap();
+
+    assert!(proof_verify::<Bls12_381, FrBls12381, HashToG1Bls12381, Bls12381Const>(pk, proof, &[], &[], disclosed_msgs.as_slice(), disclosed_indices.as_slice()).unwrap());
+
 }
+
 ```
 ## Benchmarking with Criterion
 
-benchmarking for the BBS+ signature scheme is done using [Criterion.rs](https://github.com/bheisler/criterion.rs), a powerful framework for benchmarking Rust code. The benchmarks cover the key generation, message signing, and signature verification processes.
+benchmarking for the BBS+ signature scheme is done using [Criterion.rs](https://github.com/bheisler/criterion.rs), a powerful framework for benchmarking Rust code. The benchmarks cover the key generation, message signing, signature verification, proof generation and proof verification processes. Currenlty, the benchmark is done only over BN254.
 
 To run all the benchmarks:
 ```rust

--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ fn main() {
     assert!(proof_verify(pk, proof, &[], &[], disclosed_msgs.as_slice(), disclosed_indices.as_slice()).unwrap());
 }
 ```
+## Benchmarking with Criterion
+
+benchmarking for the BBS+ signature scheme is done using [Criterion.rs](https://github.com/bheisler/criterion.rs), a powerful framework for benchmarking Rust code. The benchmarks cover the key generation, message signing, and signature verification processes.
+
+To run all the benchmarks:
+```rust
+cargo bench
+```
+You can also run specific benchmarks using `--bench` flag.
+```rust
+cargo bench --bench <benchmark_target>
+```
+The following benchmark targets are availabe: `keygen`, `sign`, `verify`(e.g., `cargo bench --bench keygen`).
+The sign and verify benchmark targets contains two benchmark function, one on single message of varying length and another on variable number of messages each of length 32bytes.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This repository implements the BBS+ signature scheme supporting over both the BN254(arkworks) and BLS12381(arkworks) pairing curve. BBS+ is a cryptographic scheme that supports efficient multi-message signing, selective disclosure, and proof of knowledge, making it suitable for privacy-preserving applications such as anonymous credentials and digital signatures.
 
-The implementation follows the specifications outlined in the [IETF draft for BBS signatures](https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html) and leverages the BN254 pairing-friendly curve for cryptographic operations.
+The implementation follows the specifications outlined in the [IETF draft for BBS signatures](https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html) and leverages the BN254 & BLS12-381 pairing-friendly curve for cryptographic operations.
 
 ## Features
 

--- a/benches/keygen.rs
+++ b/benches/keygen.rs
@@ -1,9 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
-use bbs_plus::key_gen::SecretKey;
-use ark_bn254::Bn254;
-use ark_bn254::Fr;
+use ark_bn254::{ Bn254, Fr };
 use rand::Rng;
 
+use bbs_plus::key_gen::SecretKey;
 
 pub fn keygen_benchmark(c: &mut Criterion) {
 

--- a/benches/keygen.rs
+++ b/benches/keygen.rs
@@ -1,5 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
 use bbs_plus::key_gen::SecretKey;
+use ark_bn254::Bn254;
+use ark_bn254::Fr;
 use rand::Rng;
 
 
@@ -18,7 +20,7 @@ pub fn keygen_benchmark(c: &mut Criterion) {
         let key_dst = b"BBS-SIG-KEYGEN-SALT-";
         let key_info: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect();
 
-        b.iter(|| SecretKey::key_gen(black_box(&mut key_material), black_box(&key_info), black_box(key_dst)));
+        b.iter(|| SecretKey::<Fr>::key_gen::<Bn254>(black_box(&mut key_material), black_box(&key_info), black_box(key_dst)));
 
         });
     }

--- a/benches/keygen.rs
+++ b/benches/keygen.rs
@@ -1,0 +1,31 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use bbs_plus::key_gen::SecretKey;
+use rand::Rng;
+
+
+pub fn keygen_benchmark(c: &mut Criterion) {
+
+    let mut group = c.benchmark_group("keygen");
+
+    for size in [32, 64, 128, 256, 512, 1024].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        // generating random key_material and key_info
+        let mut rng = rand::thread_rng();
+        let mut key_material: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect();
+        let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+        let key_info: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect();
+
+        b.iter(|| SecretKey::key_gen(black_box(&mut key_material), black_box(&key_info), black_box(key_dst)));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, keygen_benchmark);
+criterion_main!(benches);
+

--- a/benches/proof_gen.rs
+++ b/benches/proof_gen.rs
@@ -1,0 +1,118 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+use bbs_plus::proof_gen::proof_gen;
+
+// benchmarking proof generation on single message with varying message length
+pub fn proof_gen_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_gen_single_msg");
+
+    // message size
+    for size in [32, 64, 128, 256, 512, 1024, 2048].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+        let signature = sk.sign(&[&msg], &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(&[&msg])).unwrap());
+
+        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],&[&msg], &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof generation on multiple messages each of length 32bytes
+pub fn proof_gen_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_gen_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        let signature = sk.sign(msgs, &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+
+        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],msgs, &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof generation on multiple disclosed indices with each msg of length 32bytes
+pub fn proof_gen_benchmark_multiple_disclosed_indices(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    // random msgs of length 32 each msg of length 32
+    let random_msgs_vecs: Vec<Vec<u8>> = (0..32)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+    
+    let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+    let msgs: &[&[u8]] = &msg_slices;
+    
+    let signature = sk.sign(msgs, &[]).unwrap();
+    assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+
+    let mut group = c.benchmark_group("proof_gen_multiple_disclosed_indices");
+
+    // indices
+    for indices in [1, 2, 4, 8, 16, 32].iter() {
+
+        group.throughput(Throughput::Bytes(*indices as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(indices), indices, |b, &indices| {
+        
+        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],msgs, (0..indices).collect::<Vec<_>>().as_slice()));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = proof_gen_benchmark_single_msg, proof_gen_benchmark_multiple_msgs, proof_gen_benchmark_multiple_disclosed_indices
+}
+criterion_main!(benches);
+

--- a/benches/proof_gen.rs
+++ b/benches/proof_gen.rs
@@ -2,14 +2,18 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Benchmark
 use rand::Rng;
 use bbs_plus::key_gen::SecretKey;
 use bbs_plus::proof_gen::proof_gen;
+use ark_bn254::{Fr, Bn254};
+use bbs_plus::key_gen::PublicKey;
+use bbs_plus::constants::Bn254Const;
+use bbs_plus::utils::interface_utilities::HashToCurveBn254;
 
 // benchmarking proof generation on single message with varying message length
 pub fn proof_gen_benchmark_single_msg(c: &mut Criterion) {
 
     let mut key_material: [u8;32] = [1;32];
     let key_dst = b"BBS-SIG-KEYGEN-SALT-";
-    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
-    let pk = sk.sk_to_pk();
+    let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst).unwrap();
+    let pk: PublicKey<Bn254> = sk.sk_to_pk();
 
     let mut group = c.benchmark_group("proof_gen_single_msg");
 
@@ -21,10 +25,10 @@ pub fn proof_gen_benchmark_single_msg(c: &mut Criterion) {
 
         let mut rng = rand::thread_rng();
         let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
-        let signature = sk.sign(&[&msg], &[]).unwrap();
-        assert!(pk.verify(signature, &[], black_box(&[&msg])).unwrap());
+        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&[&msg], &[]).unwrap();
+        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, &[], black_box(&[&msg])).unwrap());
 
-        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],&[&msg], &[]));
+        b.iter(|| proof_gen::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), signature, &[], &[],&[&msg], &[]));
 
         });
     }
@@ -37,8 +41,8 @@ pub fn proof_gen_benchmark_multiple_msgs(c: &mut Criterion) {
 
     let mut key_material: [u8;32] = [1;32];
     let key_dst = b"BBS-SIG-KEYGEN-SALT-";
-    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
-    let pk = sk.sk_to_pk();
+    let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst).unwrap();
+    let pk: PublicKey<Bn254> = sk.sk_to_pk();
 
     let mut group = c.benchmark_group("proof_gen_multiple_msgs");
 
@@ -59,10 +63,10 @@ pub fn proof_gen_benchmark_multiple_msgs(c: &mut Criterion) {
         let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
         let msgs: &[&[u8]] = &msg_slices;
 
-        let signature = sk.sign(msgs, &[]).unwrap();
-        assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(msgs, &[]).unwrap();
+        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, &[], black_box(msgs)).unwrap());
 
-        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],msgs, &[]));
+        b.iter(|| proof_gen::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), signature, &[], &[],msgs, &[]));
 
         });
     }
@@ -75,8 +79,8 @@ pub fn proof_gen_benchmark_multiple_disclosed_indices(c: &mut Criterion) {
 
     let mut key_material: [u8;32] = [1;32];
     let key_dst = b"BBS-SIG-KEYGEN-SALT-";
-    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
-    let pk = sk.sk_to_pk();
+    let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst).unwrap();
+    let pk: PublicKey<Bn254> = sk.sk_to_pk();
 
     // random msgs of length 32 each msg of length 32
     let random_msgs_vecs: Vec<Vec<u8>> = (0..32)
@@ -90,8 +94,8 @@ pub fn proof_gen_benchmark_multiple_disclosed_indices(c: &mut Criterion) {
     let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
     let msgs: &[&[u8]] = &msg_slices;
     
-    let signature = sk.sign(msgs, &[]).unwrap();
-    assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+    let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(msgs, &[]).unwrap();
+    assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, &[], black_box(msgs)).unwrap());
 
     let mut group = c.benchmark_group("proof_gen_multiple_disclosed_indices");
 
@@ -101,7 +105,7 @@ pub fn proof_gen_benchmark_multiple_disclosed_indices(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(*indices as u64));
         group.bench_with_input(BenchmarkId::from_parameter(indices), indices, |b, &indices| {
         
-        b.iter(|| proof_gen(pk.clone(), signature, &[], &[],msgs, (0..indices).collect::<Vec<_>>().as_slice()));
+        b.iter(|| proof_gen::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), signature, &[], &[],msgs, (0..indices).collect::<Vec<_>>().as_slice()));
 
         });
     }

--- a/benches/proof_verify.rs
+++ b/benches/proof_verify.rs
@@ -1,0 +1,125 @@
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+use bbs_plus::proof_gen::proof_gen;
+use bbs_plus::proof_verify::proof_verify;
+
+// benchmarking proof verification on single message with varying message length
+pub fn proof_verify_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_verify_single_msg");
+
+    // message size
+    for size in [32, 64, 128, 256, 512, 1024, 2048].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+        let signature = sk.sign(&[&msg], &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(&[&msg])).unwrap());
+        let proof = proof_gen(pk.clone(), signature, &[], &[],&[&msg], &[]).unwrap();
+
+        b.iter(|| proof_verify(pk.clone(), proof.clone(), &[], &[], &[&[]], &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof verification on multiple messages each of length 32bytes
+pub fn proof_verify_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("proof_verify_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        let signature = sk.sign(msgs, &[]).unwrap();
+        assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+        let proof = proof_gen(pk.clone(), signature, &[], &[],msgs, &[]).unwrap();
+        
+        b.iter(|| proof_verify(pk.clone(), proof.clone(), &[], &[], &[&[]], &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking proof verification on multiple disclosed indices with each msg of length 32bytes
+pub fn proof_verify_benchmark_multiple_disclosed_indices(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    // random msgs of length 32 each msg of length 32
+    let random_msgs_vecs: Vec<Vec<u8>> = (0..32)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+    
+    let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+    let msgs: &[&[u8]] = &msg_slices;
+    
+    let signature = sk.sign(msgs, &[]).unwrap();
+    assert!(pk.verify(signature, &[], black_box(msgs)).unwrap());
+
+    let mut group = c.benchmark_group("proof_verify_multiple_disclosed_indices");
+
+    // indices
+    for indices in [1, 2, 4, 8, 16, 32].iter() {
+
+        group.throughput(Throughput::Bytes(*indices as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(indices), indices, |b, &indices| {
+        
+        let disclosed_indices = (0..indices).collect::<Vec<_>>();
+        let disclosed_msgs = disclosed_indices.iter().map(|i| msgs[*i]).collect::<Vec<_>>();
+        let proof = proof_gen(pk.clone(), signature, &[], &[],msgs, disclosed_indices.as_slice()).unwrap();
+        b.iter(|| proof_verify(pk.clone(), proof.clone(), &[], &[], &disclosed_msgs, &disclosed_indices));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = proof_verify_benchmark_single_msg, proof_verify_benchmark_multiple_msgs, proof_verify_benchmark_multiple_disclosed_indices
+}
+criterion_main!(benches);
+

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -1,13 +1,16 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
 use rand::Rng;
 use bbs_plus::key_gen::SecretKey;
+use ark_bn254::{Fr, Bn254};
+use bbs_plus::utils::interface_utilities::HashToCurveBn254;
+use bbs_plus::constants::Bn254Const;
 
 // benchmarking signing on single message with varying message length
 pub fn sign_benchmark_single_msg(c: &mut Criterion) {
 
     let mut key_material: [u8;32] = [1;32];
     let key_dst = b"BBS-SIG-KEYGEN-SALT-";
-    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst).unwrap();
 
     let mut group = c.benchmark_group("sign_single_msg");
 
@@ -20,7 +23,7 @@ pub fn sign_benchmark_single_msg(c: &mut Criterion) {
         let mut rng = rand::thread_rng();
         let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
 
-        b.iter(|| sk.sign(black_box(&[&msg]), &[]));
+        b.iter(|| sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(black_box(&[&msg]), &[]));
 
         });
     }
@@ -33,7 +36,7 @@ pub fn sign_benchmark_multiple_msgs(c: &mut Criterion) {
 
     let mut key_material: [u8;32] = [1;32];
     let key_dst = b"BBS-SIG-KEYGEN-SALT-";
-    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst).unwrap();
 
     let mut group = c.benchmark_group("sign_multiple_msgs");
 
@@ -54,7 +57,7 @@ pub fn sign_benchmark_multiple_msgs(c: &mut Criterion) {
         let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
         let msgs: &[&[u8]] = &msg_slices;
 
-        b.iter(|| sk.sign(black_box(msgs), &[]));
+        b.iter(|| sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(black_box(msgs), &[]));
 
         });
     }

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -1,0 +1,71 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+
+// benchmarking signing on single message with varying message length
+pub fn sign_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+
+    let mut group = c.benchmark_group("sign_single_msg");
+
+    // message size
+    for size in [128, 256, 512, 1024, 2048, 4096].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+
+        b.iter(|| sk.sign(black_box(&[&msg]), &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking signing on multiple messages each of length 32bytes
+pub fn sign_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+
+    let mut group = c.benchmark_group("sign_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        b.iter(|| sk.sign(black_box(msgs), &[]));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = sign_benchmark_single_msg, sign_benchmark_multiple_msgs
+}
+criterion_main!(benches);
+

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -1,9 +1,12 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
-use rand::Rng;
-use bbs_plus::key_gen::SecretKey;
 use ark_bn254::{Fr, Bn254};
-use bbs_plus::utils::interface_utilities::HashToCurveBn254;
-use bbs_plus::constants::Bn254Const;
+use rand::Rng;
+
+use bbs_plus::{
+    key_gen::SecretKey,
+    utils::interface_utilities::HashToG1Bn254,
+    constants::Bn254Const
+};
 
 // benchmarking signing on single message with varying message length
 pub fn sign_benchmark_single_msg(c: &mut Criterion) {
@@ -23,7 +26,7 @@ pub fn sign_benchmark_single_msg(c: &mut Criterion) {
         let mut rng = rand::thread_rng();
         let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
 
-        b.iter(|| sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(black_box(&[&msg]), &[]));
+        b.iter(|| sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(black_box(&[&msg]), &[]));
 
         });
     }
@@ -57,7 +60,7 @@ pub fn sign_benchmark_multiple_msgs(c: &mut Criterion) {
         let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
         let msgs: &[&[u8]] = &msg_slices;
 
-        b.iter(|| sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(black_box(msgs), &[]));
+        b.iter(|| sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(black_box(msgs), &[]));
 
         });
     }

--- a/benches/sign.rs
+++ b/benches/sign.rs
@@ -12,7 +12,7 @@ pub fn sign_benchmark_single_msg(c: &mut Criterion) {
     let mut group = c.benchmark_group("sign_single_msg");
 
     // message size
-    for size in [128, 256, 512, 1024, 2048, 4096].iter() {
+    for size in [32, 64, 128, 256, 512, 1024, 2048].iter() {
 
         group.throughput(Throughput::Bytes(*size as u64));
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {

--- a/benches/verify.rs
+++ b/benches/verify.rs
@@ -1,8 +1,12 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
-use rand::Rng;
-use bbs_plus::key_gen::{PublicKey, SecretKey};
 use ark_bn254::{Fr, Bn254};
-use bbs_plus::{constants::Bn254Const, utils::interface_utilities::HashToCurveBn254};
+use rand::Rng;
+
+use bbs_plus::{
+    key_gen::{PublicKey, SecretKey},
+    utils::interface_utilities::HashToG1Bn254,
+    constants::Bn254Const
+};
 
 // benchmarking signature verification on single message with varying message length
 pub fn verify_benchmark_single_msg(c: &mut Criterion) {
@@ -22,9 +26,9 @@ pub fn verify_benchmark_single_msg(c: &mut Criterion) {
 
         let mut rng = rand::thread_rng();
         let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
-        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&[&msg], &[]).unwrap();
+        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(&[&msg], &[]).unwrap();
 
-        b.iter(|| pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, &[], black_box(&[&msg])));
+        b.iter(|| pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, &[], black_box(&[&msg])));
 
         });
     }
@@ -59,9 +63,9 @@ pub fn verify_benchmark_multiple_msgs(c: &mut Criterion) {
         let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
         let msgs: &[&[u8]] = &msg_slices;
 
-        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(msgs, &[]).unwrap();
+        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(msgs, &[]).unwrap();
 
-        b.iter(|| pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, &[], black_box(msgs)));
+        b.iter(|| pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, &[], black_box(msgs)));
 
         });
     }

--- a/benches/verify.rs
+++ b/benches/verify.rs
@@ -1,0 +1,76 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use rand::Rng;
+use bbs_plus::key_gen::SecretKey;
+
+// benchmarking signature verification on single message with varying message length
+pub fn verify_benchmark_single_msg(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("verify_single_msg");
+
+    // message size
+    for size in [128, 256, 512, 1024, 2048, 4096].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let mut rng = rand::thread_rng();
+        let msg: Vec<u8> = (0..size).map(|_| rng.gen::<u8>()).collect(); // generating random message
+        let signature = sk.sign(&[&msg], &[]).unwrap();
+
+        b.iter(|| pk.verify(signature, &[], black_box(&[&msg])));
+
+        });
+    }
+
+    group.finish();
+}
+
+// benchmarking signature verification on multiple messages each of length 32bytes
+pub fn verify_benchmark_multiple_msgs(c: &mut Criterion) {
+
+    let mut key_material: [u8;32] = [1;32];
+    let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+    let sk = SecretKey::key_gen(&mut key_material, &[], key_dst).unwrap();
+    let pk = sk.sk_to_pk();
+
+    let mut group = c.benchmark_group("verify_multiple_msgs");
+
+    // numer of messages
+    for size in [1, 2, 4, 8, 16, 32, 64, 128].iter() {
+
+        group.throughput(Throughput::Bytes(*size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+
+        let random_msgs_vecs: Vec<Vec<u8>> = (0..size)
+        .map(|_| {
+            let mut rng = rand::thread_rng();
+            // each msg length of 32 bytes
+            (0..32).map(|_| rng.gen::<u8>()).collect()
+        })
+        .collect();
+
+        let msg_slices: Vec<&[u8]> = random_msgs_vecs.iter().map(|v| v.as_slice()).collect();
+        let msgs: &[&[u8]] = &msg_slices;
+
+        let signature = sk.sign(msgs, &[]).unwrap();
+
+        b.iter(|| pk.verify(signature, &[], black_box(msgs)));
+
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);  // Decrease sample size to 10
+    targets = verify_benchmark_single_msg, verify_benchmark_multiple_msgs
+}
+criterion_main!(benches);
+

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,16 +1,53 @@
-use ark_bn254::{Fr, G1Affine as G1, G2Affine as G2};
+use ark_bn254::{G1Affine as G1, G2Affine as G2};
+use ark_bls12_381::{G1Affine as G1Bls12_381, G2Affine as G2Bls12_381};
 use ark_ec::AffineRepr;
-use once_cell::sync::Lazy;
+use ark_ec::{pairing::Pairing, short_weierstrass::Projective};
 
-// BP1, BP2
-// base (constant) points on the G1 and G2 subgroups respectively
-pub static BP1: Lazy<G1> = Lazy::new(|| G1::generator());
-pub static BP2: Lazy<G2> = Lazy::new(|| G2::generator());
+pub trait Constants<E: Pairing> {
+    fn bp1() -> E::G1;
+    fn bp2() -> E::G2;
+    fn p1() -> E::G1;
+    fn p2() -> E::G2;
+}
 
-// TODO: Parameters: P1, P2: change according to ciphersuite
-// P1 and P2, fixed point of G1 and G2, defined by the ciphersuite different from BP1 and BP2.
-pub static P1: Lazy<G1> = Lazy::new(|| (G1::generator() * Fr::from(2)).into());
-pub static P2: Lazy<G2> = Lazy::new(|| (G2::generator() * Fr::from(3)).into());
+pub struct Bn254Const;
+pub struct Bls12381Const;
+
+impl <E: Pairing<G1 = Projective<ark_bn254::g1::Config>, G2 = Projective<ark_bn254::g2::Config>>>Constants<E> for Bn254Const {
+    fn bp1() -> E::G1 {
+        G1::generator().into()
+    }
+
+    fn bp2() -> E::G2 {
+        G2::generator().into()
+    }
+
+    fn p1() -> E::G1 {
+        G1::generator().into()
+    }
+
+    fn p2() -> E::G2 {
+        G2::generator().into()
+    }
+}
+
+impl <E: Pairing<G1 = Projective<ark_bls12_381::g1::Config>, G2 = Projective<ark_bls12_381::g2::Config>>>Constants<E> for Bls12381Const {
+    fn bp1() -> E::G1 {
+        G1Bls12_381::generator().into()
+    }
+
+    fn bp2() -> E::G2 {
+        G2Bls12_381::generator().into()
+    }
+
+    fn p1() -> E::G1 {
+        G1Bls12_381::generator().into()
+    }
+
+    fn p2() -> E::G2 {
+        G2Bls12_381::generator().into()
+    }
+}
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#section-7
 pub const CIPHERSUITE_ID: &[u8] = b"BBS_QUUX-V01-CS02-with-BN254G1_XMD:SHA-256_SVDW_RO_";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,10 +1,16 @@
 use ark_bn254::{
     G1Affine as G1Bn254, 
-    G2Affine as G2Bn254
+    G2Affine as G2Bn254,
+    Fr as FrBn254,
+    g1::Config as BnG1Config,
+    g2::Config as BnG2Config
 };
 use ark_bls12_381::{
+    Fr as FrBls12_381, 
     G1Affine as G1Bls12_381, 
-    G2Affine as G2Bls12_381
+    G2Affine as G2Bls12_381,
+    g1::Config as BlsG1Config,
+    g2::Config as BlsG2Config
 };
 use ark_ec::{
     AffineRepr, 
@@ -13,17 +19,22 @@ use ark_ec::{
 };
 
 #[allow(non_snake_case)]
-pub trait Constants<E: Pairing> {
+pub trait Constants<'a, E: Pairing> {
     fn BP1() -> E::G1;
     fn BP2() -> E::G2;
     fn P1() -> E::G1;
     fn P2() -> E::G2;
+
+    const CIPHERSUITE_ID: &'a [u8];
+    const SEED_DST: &'a [u8];
+    const GENERATOR_DST: &'a [u8];
+    const GENERATOR_SEED: &'a [u8];
 }
 
 pub struct Bn254Const;
 pub struct Bls12381Const;
 
-impl <E: Pairing<G1 = Projective<ark_bn254::g1::Config>, G2 = Projective<ark_bn254::g2::Config>>>Constants<E> for Bn254Const {
+impl <E: Pairing<G1 = Projective<BnG1Config>, G2 = Projective<BnG2Config>>>Constants<'_,E> for Bn254Const {
     fn BP1() -> E::G1 {
         G1Bn254::generator().into()
     }
@@ -34,16 +45,23 @@ impl <E: Pairing<G1 = Projective<ark_bn254::g1::Config>, G2 = Projective<ark_bn2
 
     //TODO: change according to draft
     fn P1() -> E::G1 {
-        G1Bn254::generator().into()
+        G1Bn254::generator() * FrBn254::from(5)
     }
 
     //TODO: change according to draft
     fn P2() -> E::G2 {
-        G2Bn254::generator().into()
+        G2Bn254::generator() * FrBn254::from(7)
     }
+
+    // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#section-7
+    const CIPHERSUITE_ID: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_";
+    const SEED_DST: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_SIG_GENERATOR_SEED_";
+    const GENERATOR_DST: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_SIG_GENERATOR_DST_";
+    const GENERATOR_SEED: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_BP_MESSAGE_GENERATOR_SEED";
+
 }
 
-impl <E: Pairing<G1 = Projective<ark_bls12_381::g1::Config>, G2 = Projective<ark_bls12_381::g2::Config>>>Constants<E> for Bls12381Const {
+impl <E: Pairing<G1 = Projective<BlsG1Config>, G2 = Projective<BlsG2Config>>>Constants<'_,E> for Bls12381Const {
     fn BP1() -> E::G1 {
         G1Bls12_381::generator().into()
     }
@@ -54,17 +72,19 @@ impl <E: Pairing<G1 = Projective<ark_bls12_381::g1::Config>, G2 = Projective<ark
 
     //TODO: change according to draft
     fn P1() -> E::G1 {
-        G1Bls12_381::generator().into()
+        G1Bls12_381::generator() * FrBls12_381::from(5)
     }
 
     //TODO: change according to draft
     fn P2() -> E::G2 {
-        G2Bls12_381::generator().into()
+        G2Bls12_381::generator() * FrBls12_381::from(7)
     }
-}
 
-// https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#section-7
-pub const CIPHERSUITE_ID: &[u8] = b"BBS_QUUX-V01-CS02-with-BN254G1_XMD:SHA-256_SVDW_RO_";
-pub const SEED_DST: &[u8] = b"BBS_QUUX-V01-CS02-with-BN254G1_XMD:SHA-256_SVDW_RO_H2G_HM2S_SIG_GENERATOR_SEED_";
-pub const GENERATOR_DST: &[u8] = b"BBS_QUUX-V01-CS02-with-BN254G1_XMD:SHA-256_SVDW_RO_H2G_HM2S_SIG_GENERATOR_DST_";
-pub const GENERATOR_SEED: &[u8] = b"BBS_QUUX-V01-CS02-with-BN254G1_XMD:SHA-256_SVDW_RO_H2G_HM2S_BP_MESSAGE_GENERATOR_SEED";
+
+    // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#section-7
+    const CIPHERSUITE_ID: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_";
+    const SEED_DST: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_SIG_GENERATOR_SEED_";
+    const GENERATOR_DST: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_SIG_GENERATOR_DST_";
+    const GENERATOR_SEED: &'static[u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_BP_MESSAGE_GENERATOR_SEED";
+
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,10 +32,12 @@ impl <E: Pairing<G1 = Projective<ark_bn254::g1::Config>, G2 = Projective<ark_bn2
         G2Bn254::generator().into()
     }
 
+    //TODO: change according to draft
     fn P1() -> E::G1 {
         G1Bn254::generator().into()
     }
 
+    //TODO: change according to draft
     fn P2() -> E::G2 {
         G2Bn254::generator().into()
     }
@@ -50,10 +52,12 @@ impl <E: Pairing<G1 = Projective<ark_bls12_381::g1::Config>, G2 = Projective<ark
         G2Bls12_381::generator().into()
     }
 
+    //TODO: change according to draft
     fn P1() -> E::G1 {
         G1Bls12_381::generator().into()
     }
 
+    //TODO: change according to draft
     fn P2() -> E::G2 {
         G2Bls12_381::generator().into()
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,50 +1,60 @@
-use ark_bn254::{G1Affine as G1, G2Affine as G2};
-use ark_bls12_381::{G1Affine as G1Bls12_381, G2Affine as G2Bls12_381};
-use ark_ec::AffineRepr;
-use ark_ec::{pairing::Pairing, short_weierstrass::Projective};
+use ark_bn254::{
+    G1Affine as G1Bn254, 
+    G2Affine as G2Bn254
+};
+use ark_bls12_381::{
+    G1Affine as G1Bls12_381, 
+    G2Affine as G2Bls12_381
+};
+use ark_ec::{
+    AffineRepr, 
+    pairing::Pairing, 
+    short_weierstrass::Projective
+};
 
+#[allow(non_snake_case)]
 pub trait Constants<E: Pairing> {
-    fn bp1() -> E::G1;
-    fn bp2() -> E::G2;
-    fn p1() -> E::G1;
-    fn p2() -> E::G2;
+    fn BP1() -> E::G1;
+    fn BP2() -> E::G2;
+    fn P1() -> E::G1;
+    fn P2() -> E::G2;
 }
 
 pub struct Bn254Const;
 pub struct Bls12381Const;
 
 impl <E: Pairing<G1 = Projective<ark_bn254::g1::Config>, G2 = Projective<ark_bn254::g2::Config>>>Constants<E> for Bn254Const {
-    fn bp1() -> E::G1 {
-        G1::generator().into()
+    fn BP1() -> E::G1 {
+        G1Bn254::generator().into()
     }
 
-    fn bp2() -> E::G2 {
-        G2::generator().into()
+    fn BP2() -> E::G2 {
+        G2Bn254::generator().into()
     }
 
-    fn p1() -> E::G1 {
-        G1::generator().into()
+    fn P1() -> E::G1 {
+        G1Bn254::generator().into()
     }
 
-    fn p2() -> E::G2 {
-        G2::generator().into()
+    fn P2() -> E::G2 {
+        G2Bn254::generator().into()
     }
 }
 
 impl <E: Pairing<G1 = Projective<ark_bls12_381::g1::Config>, G2 = Projective<ark_bls12_381::g2::Config>>>Constants<E> for Bls12381Const {
-    fn bp1() -> E::G1 {
+    fn BP1() -> E::G1 {
         G1Bls12_381::generator().into()
     }
 
-    fn bp2() -> E::G2 {
+    fn BP2() -> E::G2 {
         G2Bls12_381::generator().into()
     }
 
-    fn p1() -> E::G1 {
+    fn P1() -> E::G1 {
         G1Bls12_381::generator().into()
     }
 
-    fn p2() -> E::G2 {
+    fn P2() -> E::G2 {
         G2Bls12_381::generator().into()
     }
 }

--- a/src/key_gen.rs
+++ b/src/key_gen.rs
@@ -1,23 +1,28 @@
-use ark_bn254::{ Fr, G2Affine as G2};
-use ark_ec::{ CurveGroup, AffineRepr };
+// use ark_bn254::{ Fr, G2Affine as G2};
+// use ark_ec::{ CurveGroup, AffineRepr };
 use zeroize::{Zeroize, ZeroizeOnDrop};
 use digest::generic_array::{GenericArray, typenum::U48};
 use ark_serialize::{ CanonicalSerialize, CanonicalDeserialize };
 use thiserror::Error;
 
-use crate::utils::utilities_helper::FromOkm;
+// use crate::utils::utilities_helper::FromOkm;
 use crate::utils::core_utilities::hash_to_scalar;
+use ark_ff::Field;
+use ark_ec::pairing::Pairing;
+use crate::utils::utilities_helper;
+use ark_ec::Group;
+use elliptic_curve::ops::Mul;
 
 // Public Key
 #[derive(Debug, Default,CanonicalDeserialize, CanonicalSerialize, Clone)]
-pub struct PublicKey{
-    pub pk: G2
+pub struct PublicKey<E: Pairing>{
+    pub pk: E::G2
 }
 
 // Secret Key
 #[derive(Debug, Default, Zeroize, ZeroizeOnDrop, CanonicalDeserialize, CanonicalSerialize)]
-pub struct SecretKey{
-    pub sk: Fr
+pub struct SecretKey<F: Field>{
+    pub sk: F,
 }
 
 #[derive(Debug, Error)]
@@ -31,10 +36,14 @@ pub enum KeyGenError {
     
 }
 
-impl SecretKey {
+impl <F: Field>SecretKey<F> {
 
     // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-secret-key
-    pub fn key_gen(key_material: &mut [u8], key_info: &[u8],key_dst: &[u8]) -> Result<Self, KeyGenError> {
+    pub fn key_gen<E, const L: usize>(key_material: &mut [u8], key_info: &[u8],key_dst: &[u8]) -> Result<Self, KeyGenError> 
+    
+    where
+    E: Pairing,
+    F: Field + utilities_helper::FromOkm<L, F>,{
 
         if key_material.len() < 32 {
             return Err(KeyGenError::InvalidKeyMaterialLength);
@@ -56,7 +65,7 @@ impl SecretKey {
         // zeroize key_material after use
         key_material.zeroize();
 
-        if sk == Fr::from(0) {
+        if sk == F::ZERO {
             return Err(KeyGenError::InvalidSecretKey);
         }
 
@@ -65,15 +74,21 @@ impl SecretKey {
         })
     }
 
-    pub fn sk_to_pk(&self) -> PublicKey {
+    pub fn sk_to_pk<E: Pairing>(&self) -> PublicKey<E> 
+    where <E as Pairing>::G2: Mul<F>, <E as Pairing>::G2: From<<<E as Pairing>::G2 as Mul<F>>::Output>
+    {
         PublicKey{
-            pk: (G2::generator() * self.sk).into_affine()}
+            pk: (E::G2::generator() * self.sk).into()}
     }
 
     // TODO: may not be required. `key_gen` implements the generation of secret key according to the spec
     // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#name-keygen
     // https://github.com/mattrglobal/bbs-signatures/blob/e0ae711ce8da425d671c748201106a5d1bf2bd5b/src/bls12381.rs#L354
-    pub fn gen_sk(msg: &[u8]) -> Self {
+    pub fn gen_sk<E, const L: usize>(msg: &[u8]) -> Self 
+    where
+    E: Pairing,
+    F: Field + utilities_helper::FromOkm<L, F>,
+    {
         const SALT: &[u8] = b"BBS-SIG-KEYGEN-SALT-";
         // copy of `msg` with appended zero byte
         let mut msg_prime = Vec::<u8>::with_capacity(msg.as_ref().len() + 1);
@@ -82,11 +97,11 @@ impl SecretKey {
         // `result` has enough length to hold the output from HKDF expansion
         let mut result = GenericArray::<u8, U48>::default();
         assert!(hkdf::Hkdf::<sha2::Sha256>::new(Some(SALT), &msg_prime[..])
-            .expand(&[0, 48], &mut result)
+            .expand(&[0, L.try_into().unwrap()], &mut result)
             .is_ok());
-        let result_array: [u8;48] = result.as_slice().try_into().expect("wrong length!");
+        let result_array: [u8;L] = result.as_slice().try_into().expect("wrong length!");
         
-        Self{sk: Fr::from_okm(&result_array)}
+        Self{sk: F::from_okm(&result_array)}
     }
 
 }
@@ -96,6 +111,10 @@ mod tests {
     use crate::key_gen::SecretKey;
     use zeroize::Zeroize;
     use ark_bn254::Fr;
+    use ark_bn254::Bn254;
+    use crate::key_gen::PublicKey;
+    use ark_bls12_381::{Bls12_381, Fr as FrBls12_381};
+
 
     #[test]
     fn test_key_gen() {
@@ -104,10 +123,10 @@ mod tests {
         let key_dst = b"BBS-SIG-KEYGEN-SALT-";
 
         // key_info and key_dst are optional
-        let sk1 = SecretKey::key_gen(&mut key_material1, &[], key_dst.as_slice()).unwrap();
-        let sk2 = SecretKey::key_gen(&mut key_material2, &[], key_dst.as_slice()).unwrap();
-        let pk1 = SecretKey::sk_to_pk(&sk1);
-        let pk2 = SecretKey::sk_to_pk(&sk2);
+        let sk1: SecretKey<Fr> = SecretKey::key_gen::<Bn254, 48>(&mut key_material1, &[], key_dst.as_slice()).unwrap();
+        let sk2: SecretKey<Fr> = SecretKey::key_gen::<Bn254, 48>(&mut key_material2, &[], key_dst.as_slice()).unwrap();
+        let pk1: PublicKey<Bn254> = SecretKey::sk_to_pk(&sk1);
+        let pk2: PublicKey<Bn254> = SecretKey::sk_to_pk(&sk2);
 
         // check sk is non-zero
         assert!(sk1.sk != Fr::from(0));
@@ -126,8 +145,8 @@ mod tests {
         let key_dst = b"BBS-SIG-KEYGEN-SALT-";
 
         // key_info and key_dst are optional
-        let mut sk = SecretKey::key_gen(&mut key_material, &[], key_dst.as_slice()).unwrap();
-        let _ = SecretKey::sk_to_pk(&sk);
+        let mut sk: SecretKey<Fr> = SecretKey::key_gen::<Bn254, 48>(&mut key_material, &[], key_dst.as_slice()).unwrap();
+        let _: PublicKey<Bn254> = SecretKey::sk_to_pk(&sk);
         
         // zeroize the secret key after generating public key
         sk.zeroize();
@@ -145,7 +164,7 @@ mod tests {
         let key_dst = b"BBS-SIG-KEYGEN-SALT-";
 
         // key_info and key_dst are optional
-        let sk1 = SecretKey::key_gen(&mut key_material, &[], key_dst.as_slice());
+        let sk1: Result<SecretKey<Fr>, crate::key_gen::KeyGenError> = SecretKey::key_gen::<Bn254, 48>(&mut key_material, &[], key_dst.as_slice());
         assert!(sk1.is_err());
 
 
@@ -153,8 +172,31 @@ mod tests {
         // key_info should be at most 65535
         let key_info_arr = [1u8; 65536];
 
-        let sk1 = SecretKey::key_gen(&mut key_material, key_info_arr.as_slice(), key_dst.as_slice());
+        let sk1: Result<SecretKey<Fr>, crate::key_gen::KeyGenError> = SecretKey::key_gen::<Bn254, 48>(&mut key_material, key_info_arr.as_slice(), key_dst.as_slice());
         assert!(sk1.is_err());
+    }
+
+    #[test]
+    fn test_key_gen_bls() {
+        let mut key_material1 = [1u8; 32];
+        let mut key_material2 = [1u8; 32];
+        let key_dst = b"BBS-SIG-KEYGEN-SALT-";
+
+        // key_info and key_dst are optional
+        let sk1: SecretKey<FrBls12_381> = SecretKey::key_gen::<Bls12_381, 48>(&mut key_material1, &[], key_dst.as_slice()).unwrap();
+        let sk2: SecretKey<FrBls12_381> = SecretKey::key_gen::<Bls12_381, 48>(&mut key_material2, &[], key_dst.as_slice()).unwrap();
+        let pk1: PublicKey<Bls12_381> = SecretKey::sk_to_pk(&sk1);
+        let pk2: PublicKey<Bls12_381> = SecretKey::sk_to_pk(&sk2);
+
+        // check sk is non-zero
+        assert!(sk1.sk != FrBls12_381::from(0));
+
+        // check key_material is zeroid after use
+        assert!(key_material1 == [0u8; 32]);
+        assert!(key_material2 == [0u8; 32]);
+
+        // check pk is generated deterministically
+        assert_eq!(pk1.pk, pk2.pk);
     }
 
 }

--- a/src/key_gen.rs
+++ b/src/key_gen.rs
@@ -13,9 +13,20 @@ use crate::utils::core_utilities::hash_to_scalar;
 use crate::utils::utilities_helper;
 
 // Public Key
-#[derive(Debug, Default,CanonicalDeserialize, CanonicalSerialize, Clone)]
+#[derive(Debug,CanonicalDeserialize, CanonicalSerialize, Clone)]
 pub struct PublicKey<E: Pairing>{
     pub pk: E::G2
+}
+
+impl<E: Pairing> Default for PublicKey<E> 
+where
+    E::G2: Default,
+{
+    fn default() -> Self {
+        PublicKey {
+            pk: E::G2::default(),
+        }
+    }
 }
 
 // Secret Key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,13 @@ pub mod utils {
     pub mod utilities_helper;
 }
 pub mod key_gen;
-pub mod sign;
-pub mod verify;
-pub mod constants;
-pub mod proof_gen;
-pub mod proof_verify;
-pub mod tests{
-    pub mod core_sign_tests;
-    pub mod sign_verify_tests;
-    pub mod proof_verify_tests;
-}
+// pub mod sign;
+// pub mod verify;
+// pub mod constants;
+// pub mod proof_gen;
+// pub mod proof_verify;
+// pub mod tests{
+//     pub mod core_sign_tests;
+//     pub mod sign_verify_tests;
+//     pub mod proof_verify_tests;
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,13 @@ pub mod utils {
     pub mod utilities_helper;
 }
 pub mod key_gen;
-// pub mod sign;
-// pub mod verify;
-// pub mod constants;
+pub mod sign;
+pub mod verify;
+pub mod constants;
 // pub mod proof_gen;
 // pub mod proof_verify;
-// pub mod tests{
-//     pub mod core_sign_tests;
-//     pub mod sign_verify_tests;
-//     pub mod proof_verify_tests;
-// }
+pub mod tests{
+    pub mod core_sign_tests;
+    pub mod sign_verify_tests;
+    // pub mod proof_verify_tests;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,5 @@ pub mod tests{
     pub mod core_sign_tests;
     pub mod sign_verify_tests;
     pub mod proof_verify_tests;
+    pub mod bbs_over_bls_tests;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,10 @@ pub mod key_gen;
 pub mod sign;
 pub mod verify;
 pub mod constants;
-// pub mod proof_gen;
-// pub mod proof_verify;
+pub mod proof_gen;
+pub mod proof_verify;
 pub mod tests{
     pub mod core_sign_tests;
     pub mod sign_verify_tests;
-    // pub mod proof_verify_tests;
+    pub mod proof_verify_tests;
 }

--- a/src/proof_gen.rs
+++ b/src/proof_gen.rs
@@ -24,10 +24,7 @@ use crate::utils::{
 use crate::{
     key_gen::PublicKey,
     sign::Signature,
-    constants::{
-        CIPHERSUITE_ID,
-        Constants,
-    }
+    constants::Constants,
 };
 
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, Default)]
@@ -96,13 +93,13 @@ where
     E: Pairing,
     F: Field+ FromOkm<48, F>,
     H: HashToG1<E>,
-    C: Constants<E>,
+    C: for<'a> Constants<'a, E>,
     E::G2: Mul<F, Output = E::G2>,
     E::G1: Mul<F, Output = E::G1>,
 
 {
 
-    let api_id = [CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
+    let api_id = [C::CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
     let message_scalars = msg_to_scalars::<E, F, 48>(messages, &api_id);
     let generators = create_generators::<E, H>(messages.len() + 1, &api_id);
 
@@ -115,7 +112,7 @@ pub(crate) fn core_proof_gen<E, F, C>(pk: PublicKey<E>, signature: Signature<E, 
 where
     E: Pairing,
     F: Field+ FromOkm<48, F>,
-    C: Constants<E>,
+    C: for<'a> Constants<'a, E>,
     E::G2: Mul<F, Output = E::G2>,
     E::G1: Mul<F, Output = E::G1>,
 
@@ -188,7 +185,7 @@ pub(crate) fn proof_init<E, F, C>(pk: PublicKey<E>, signature: Signature<E, F>, 
 where
     E: Pairing,
     F: Field + FromOkm<48, F>,
-    C: Constants<E>,
+    C: for<'a> Constants<'a, E>,
     E::G2: Mul<F, Output = E::G2>,
     E::G1: Mul<F, Output = E::G1>,
 {

--- a/src/proof_gen.rs
+++ b/src/proof_gen.rs
@@ -1,6 +1,7 @@
-use ark_bn254::{Fr, G1Affine as G1, G1Projective};
+// use ark_bn254::{Fr, G1Affine as G1, G1Projective};
+use ark_ec::pairing::Pairing;
 use ark_serialize::{CanonicalSerialize,CanonicalDeserialize};
-use ark_ec::AffineRepr;
+// use ark_ec::AffineRepr;
 use ark_ff::Field;
 use std::collections::HashSet;
 use std::iter::FromIterator;
@@ -10,30 +11,54 @@ use crate::utils::core_utilities::{calculate_domain, hash_to_scalar, calculate_r
 use crate::utils::interface_utilities::{msg_to_scalars, create_generators};
 use crate::key_gen::PublicKey;
 use crate::sign::Signature;
-use crate::constants::{P1, CIPHERSUITE_ID};
+use crate::constants::CIPHERSUITE_ID;
+use crate::utils::utilities_helper;
+use crate::utils::interface_utilities::HashToG1;
+use crate::constants::Constants;
+use elliptic_curve::ops::Mul;
+
 
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, Default)]
-pub struct InitProof {
-    pub points: [G1;5],
-    pub scalar: Fr,
+pub struct InitProof<E: Pairing, F: Field> {
+    pub points: [E::G1;5],
+    pub scalar: F,
 }
 
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, Default)]
-pub struct Challenge {
-    pub scalar: Fr,
+pub struct Challenge<F: Field> {
+    pub scalar: F,
 }
 
-#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize, Default)]
-pub struct Proof {
+#[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]
+pub struct Proof<E: Pairing, F: Field> {
     
-    pub a_bar: G1,
-    pub b_bar: G1,
-    pub d: G1,
-    pub e_cap: Fr,
-    pub r1_cap: Fr,
-    pub r3_cap: Fr,
-    pub commitments: Vec<Fr>,
-    pub challenge: Challenge,
+    pub a_bar: E::G1,
+    pub b_bar: E::G1,
+    pub d: E::G1,
+    pub e_cap: F,
+    pub r1_cap: F,
+    pub r3_cap: F,
+    pub commitments: Vec<F>,
+    pub challenge: Challenge<F>,
+}
+
+impl<E: Pairing, F: Field> Default for Proof<E, F>
+where
+    E::G1: Default,
+    F: Default,
+{
+    fn default() -> Self {
+        Proof {
+            a_bar: E::G1::default(),
+            b_bar: E::G1::default(),
+            d: E::G1::default(),
+            e_cap: F::default(),
+            r1_cap: F::default(),
+            r3_cap: F::default(),
+            commitments: Vec::new(),
+            challenge: Challenge::default()
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -54,17 +79,35 @@ pub enum ProofGenError {
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-proof-generation-proofgen
-pub fn proof_gen(pk: PublicKey, signature: Signature, header: &[u8], ph: &[u8], messages: &[&[u8]], disclosed_indexes: &[usize]) -> Result<Proof, ProofGenError> {
+pub fn proof_gen<E: Pairing, F: Field+ utilities_helper::FromOkm<48, F>, H: HashToG1<E>, C>(pk: PublicKey<E>, signature: Signature<E,F>, header: &[u8], ph: &[u8], messages: &[&[u8]], disclosed_indexes: &[usize]) -> Result<Proof<E, F>, ProofGenError> 
+
+where
+    E: Pairing,
+    C: Constants<E>,
+    // H: HashToG1<E>,
+    E::G2: Mul<F, Output = E::G2>,
+    E::G1: Mul<F, Output = E::G1>,
+
+{
 
     let api_id = [CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
-    let message_scalars = msg_to_scalars(messages, &api_id);
-    let generators = create_generators(messages.len() + 1, &api_id);
+    let message_scalars = msg_to_scalars::<E, F, 48>(messages, &api_id);
+    let generators = create_generators::<E, H>(messages.len() + 1, &api_id);
 
-    core_proof_gen(pk, signature, header, &generators, ph, &message_scalars, disclosed_indexes, &api_id)
+    core_proof_gen::<E, F, C>(pk, signature, header, &generators, ph, &message_scalars, disclosed_indexes, &api_id)
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-coreproofgen
-pub(crate) fn core_proof_gen(pk: PublicKey, signature: Signature, header: &[u8], generators: &[G1], ph: &[u8], messages: &[Fr], disclosed_indexes: &[usize], api_id: &[u8]) -> Result<Proof, ProofGenError> {
+pub(crate) fn core_proof_gen<E: Pairing, F: Field+ utilities_helper::FromOkm<48, F>, C>(pk: PublicKey<E>, signature: Signature<E, F>, header: &[u8], generators: &[E::G1], ph: &[u8], messages: &[F], disclosed_indexes: &[usize], api_id: &[u8]) -> Result<Proof<E, F>, ProofGenError> 
+
+where
+    E: Pairing,
+    C: Constants<E>,
+    // H: HashToG1<E>,
+    E::G2: Mul<F, Output = E::G2>,
+    E::G1: Mul<F, Output = E::G1>,
+
+{
 
     let l = messages.len();
     let r = disclosed_indexes.len();
@@ -78,7 +121,7 @@ pub(crate) fn core_proof_gen(pk: PublicKey, signature: Signature, header: &[u8],
         }
     }
 
-    let random_scalars = calculate_random_scalars(5 + l - r);
+    let random_scalars = calculate_random_scalars::<48, F>(5 + l - r);
 
     let full_indexes: HashSet<usize> = HashSet::from_iter(0..l);
     let disclosed_set: HashSet<usize> = HashSet::from_iter(disclosed_indexes.iter().cloned());
@@ -91,7 +134,7 @@ pub(crate) fn core_proof_gen(pk: PublicKey, signature: Signature, header: &[u8],
     let mut undisclosed_indexes: Vec<usize> = undisclosed_set.into_iter().collect();
     undisclosed_indexes.sort();
 
-    let init_res = proof_init(
+    let init_res = proof_init::<E, F, C>(
         pk,
         signature,
         generators,
@@ -107,13 +150,13 @@ pub(crate) fn core_proof_gen(pk: PublicKey, signature: Signature, header: &[u8],
     }
     let init_res = init_res.unwrap();
 
-    let disclosed_messages: Vec<Fr> = disclosed_indexes
+    let disclosed_messages: Vec<F> = disclosed_indexes
     .iter()
     .filter_map(|&i| messages.get(i).cloned())
     .collect();
 
 
-    let undisclosed_messages: Vec<Fr> = undisclosed_indexes
+    let undisclosed_messages: Vec<F> = undisclosed_indexes
     .iter()
     .filter_map(|&i| messages.get(i).cloned())
     .collect();
@@ -129,7 +172,16 @@ pub(crate) fn core_proof_gen(pk: PublicKey, signature: Signature, header: &[u8],
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-proof-initialization
-pub(crate) fn proof_init(pk: PublicKey, signature: Signature, generators: &[G1], random_scalars: &[Fr], header: &[u8], messages: &[Fr], undisclosed_indexes: &[usize], api_id: &[u8]) -> Result<InitProof, ProofGenError> {
+pub(crate) fn proof_init<E: Pairing, F: Field + utilities_helper::FromOkm<48, F>, C: Constants<E>>(pk: PublicKey<E>, signature: Signature<E, F>, generators: &[E::G1], random_scalars: &[F], header: &[u8], messages: &[F], undisclosed_indexes: &[usize], api_id: &[u8]) -> Result<InitProof<E, F>, ProofGenError> 
+
+where
+    E: Pairing,
+    C: Constants<E>,
+    // H: HashToG1<E>,
+    E::G2: Mul<F, Output = E::G2>,
+    E::G1: Mul<F, Output = E::G1>,
+
+{
 
     if messages.len() + 1 != generators.len() {
         return Err(ProofGenError::InvalidMessageAndGeneratorsLength);
@@ -143,9 +195,9 @@ pub(crate) fn proof_init(pk: PublicKey, signature: Signature, generators: &[G1],
         return Err(ProofGenError::InvalidUndisclosedIndicesLength);
     }
 
-    let domain = calculate_domain(&pk, generators[0], &generators[1..], header, api_id);
+    let domain = calculate_domain::<E, F, 48>(&pk, generators[0], &generators[1..], header, api_id);
 
-    let mut b: G1Projective = P1.into_group() + generators[0] * domain;
+    let mut b: E::G1 = C::bp1() + generators[0] * domain;
 
     for i in 0..messages.len() {
         b = b + (generators[i+1] * messages[i]);
@@ -162,13 +214,13 @@ pub(crate) fn proof_init(pk: PublicKey, signature: Signature, generators: &[G1],
     }
 
     Ok(InitProof{
-        points: [a_bar.into(), b_bar.into(), d.into(), t1.into(), t2.into()],
+        points: [a_bar, b_bar, d, t1, t2],
         scalar: domain,
     })   
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-challenge-calculation
-pub(crate) fn proof_challenge_calculate(init_res: &InitProof, disclosed_messages: &[Fr], disclosed_indexes: &[usize], ph: &[u8], api_id: &[u8]) -> Result<Challenge, ProofGenError> {
+pub(crate) fn proof_challenge_calculate<E: Pairing, F: Field+ utilities_helper::FromOkm<48, F>>(init_res: &InitProof<E, F>, disclosed_messages: &[F], disclosed_indexes: &[usize], ph: &[u8], api_id: &[u8]) -> Result<Challenge<F>, ProofGenError> {
     
     if disclosed_messages.len() != disclosed_indexes.len() {
         return Err(ProofGenError::InvalidIndicesAndMessagesLength);
@@ -206,13 +258,13 @@ pub(crate) fn proof_challenge_calculate(init_res: &InitProof, disclosed_messages
     serialize_bytes.extend_from_slice(&ph);
 
     Ok(Challenge { 
-        scalar: hash_to_scalar(&serialize_bytes, &hash_to_scalar_dst) 
+        scalar: hash_to_scalar::<48, F>(&serialize_bytes, &hash_to_scalar_dst) 
     })
 
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-proof-finalization
-pub(crate) fn proof_finalize(init_res: &InitProof, challenge: &Challenge, e_value: Fr, random_scalars: &[Fr], undisclosed_messages: &[Fr]) -> Result<Proof, ProofGenError> {
+pub(crate) fn proof_finalize<E: Pairing, F: Field>(init_res: &InitProof<E, F>, challenge: &Challenge<F>, e_value: F, random_scalars: &[F], undisclosed_messages: &[F]) -> Result<Proof<E, F>, ProofGenError> {
 
     if random_scalars.len() != undisclosed_messages.len() + 5 {
         return Err(ProofGenError::InvalidRandomScalarsAndUndisclosedIndicesLength);

--- a/src/proof_verify.rs
+++ b/src/proof_verify.rs
@@ -23,10 +23,7 @@ use crate::{
         },
         utilities_helper::FromOkm,
     },
-    constants::{
-        CIPHERSUITE_ID,
-        Constants,
-    }
+    constants::Constants,
 };
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-proof-verification-proofver
@@ -35,13 +32,13 @@ pub fn proof_verify<E, F, H, C>(pk: PublicKey<E>, proof: Proof<E, F>, header: &[
 where
     E: Pairing,
     F: Field+ FromOkm<48, F>,
-    C: Constants<E>,
+    C: for<'a> Constants<'a, E>,
     H: HashToG1<E>,
     E::G2: Mul<F, Output = E::G2>,
     E::G1: Mul<F, Output = E::G1>,
 {
 
-    let api_id = [CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
+    let api_id = [C::CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
 
     let message_scalars = msg_to_scalars::<E, F, 48>(disclosed_messages, &api_id);
     let generators = create_generators::<E, H>(proof.commitments.len() + disclosed_indexes.len() + 1, &api_id);
@@ -54,7 +51,7 @@ pub(crate) fn core_proof_verify<E, F, C>(pk: PublicKey<E>, proof: Proof<E, F>, g
 where
     E: Pairing,
     F: Field+ FromOkm<48, F>,
-    C: Constants<E>,
+    C: for<'a> Constants<'a, E>,
     E::G2: Mul<F, Output = E::G2>,
     E::G1: Mul<F, Output = E::G1>,
 {
@@ -85,7 +82,7 @@ pub(crate) fn proof_verify_init<E, F, C>(pk: PublicKey<E>, proof: Proof<E, F>, g
 where
     E: Pairing,
     F: Field+ FromOkm<48, F>,
-    C: Constants<E>,
+    C: for<'a> Constants<'a, E>,
     E::G2: Mul<F, Output = E::G2>,
     E::G1: Mul<F, Output = E::G1>,
 {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -6,10 +6,7 @@ use ark_ec::pairing::Pairing;
 
 use crate::{
     key_gen::SecretKey,
-    constants::{
-        CIPHERSUITE_ID,
-        Constants
-    },
+    constants::Constants,
     utils::{
         core_utilities::{
             hash_to_scalar,
@@ -43,13 +40,13 @@ impl < F: Field+ FromOkm<48, F>>SecretKey<F> {
     pub fn sign<E, C, H>(&self, messages: &[&[u8]], header: &[u8]) ->  Result<Signature<E, F>, SignatureError>  
     where
         E: Pairing,
-        C: Constants<E>,
+        C: for<'a> Constants<'a, E>,
         H: HashToG1<E>,
         E::G2: Mul<F, Output = E::G2>,
         E::G1: Mul<F, Output = E::G1>,
     {
 
-        let api_id = [CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
+        let api_id = [C::CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
 
         let message_scalars = msg_to_scalars::<E, F, 48>(messages, &api_id);
         let generators = create_generators::<E, H>(messages.len() + 1, &api_id);
@@ -61,7 +58,7 @@ impl < F: Field+ FromOkm<48, F>>SecretKey<F> {
     pub(crate) fn core_sign<E, C>(&self, generators: &[E::G1], header: &[u8], messages: &[F], api_id: &[u8]) -> Result<Signature<E, F>, SignatureError>  
     where 
         E: Pairing,
-        C: Constants<E>,
+        C: for<'a> Constants<'a, E>,
         E::G2: Mul<F, Output = E::G2>,
         E::G1: Mul<F, Output = E::G1>,
     {

--- a/src/tests/bbs_over_bls_tests.rs
+++ b/src/tests/bbs_over_bls_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use ark_bn254::{Bn254, Fr, G1Affine as G1};
+    use ark_bls12_381::{Fr, Bls12_381, G1Affine as G1};
     use test_case::test_case;
     use rand::Rng;
 
@@ -8,16 +8,16 @@ mod tests {
         key_gen::{PublicKey, SecretKey},
         proof_gen::{proof_gen, Proof},
         proof_verify::proof_verify,
-        constants::Bn254Const,
-        utils::interface_utilities::HashToG1Bn254,
+        constants::Bls12381Const,
+        utils::interface_utilities::HashToG1Bls12381,
     };
     
-    fn generate_key() -> (SecretKey<Fr>, PublicKey<Bn254>){
+    fn generate_key() -> (SecretKey<Fr>, PublicKey<Bls12_381>){
 
         let mut key_material = [1u8; 32];
         let key_dst = b"BBS-SIG-KEYGEN-SALT-";
 
-        let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst.as_slice()).unwrap();
+        let sk = SecretKey::<Fr>::key_gen::<Bls12_381>(&mut key_material, &[], key_dst.as_slice()).unwrap();
         let pk = SecretKey::sk_to_pk(&sk);
 
         (sk, pk)
@@ -53,13 +53,13 @@ mod tests {
 
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
-        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(&msg_slices, header).unwrap();
-        assert!(pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, header, &msg_slices).unwrap());
+        let signature = sk.sign::<Bls12_381, Bls12381Const, HashToG1Bls12381>(&msg_slices, header).unwrap();
+        assert!(pk.verify::<Fr, HashToG1Bls12381, Bls12381Const>(signature, header, &msg_slices).unwrap());
 
         let disclosed_msgs: Vec<&[u8]> = disclosed_indexes.iter().map(|i| msg_slices[*i]).collect();
 
-        let proof = proof_gen::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), signature, header, &[], &msg_slices, disclosed_indexes.as_slice());
-        assert!(proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk, proof.unwrap(), header, &[], disclosed_msgs.as_slice(), disclosed_indexes.as_slice()).unwrap());
+        let proof = proof_gen::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(pk.clone(), signature, header, &[], &msg_slices, disclosed_indexes.as_slice());
+        assert!(proof_verify::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(pk, proof.unwrap(), header, &[], disclosed_msgs.as_slice(), disclosed_indexes.as_slice()).unwrap());
     }
 
     #[test]
@@ -68,11 +68,11 @@ mod tests {
         let (sk, pk) = generate_key();
         let messages = generate_random_msg(10);
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
-        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(&msg_slices, b"").unwrap();
-        let proof = proof_gen::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), signature, b"", &[], &msg_slices, &[0,1,5]).unwrap();
+        let signature = sk.sign::<Bls12_381, Bls12381Const, HashToG1Bls12381>(&msg_slices, b"").unwrap();
+        let proof = proof_gen::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(pk.clone(), signature, b"", &[], &msg_slices, &[0,1,5]).unwrap();
 
         // correct proof
-        assert!(proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), proof.clone(), b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(proof_verify::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(pk.clone(), proof.clone(), b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
 
         // case 1
         // forged proof
@@ -80,29 +80,29 @@ mod tests {
         forged_proof.a_bar = G1::identity().into();
 
         // should fail because of forged a_bar
-        assert!(!proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
         
         // case 2
         // default proof should fail
-        let forged_proof = Proof::<Bn254, Fr>{
+        let forged_proof = Proof::<Bls12_381, Fr>{
             ..Default::default()
         };
 
         // result into error because of forged proof(commitment length is zero)
-        assert!(proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).is_err());
+        assert!(proof_verify::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).is_err());
 
         // case 3
         // forged public key
         let forged_pk = PublicKey{
             ..Default::default()
         };
-        assert!(!proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(forged_pk, proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(forged_pk, proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
 
         // case 4
         let forged_proof = Proof{
             commitments: vec![Fr::from(0); 7],  // 10-3 where 3 is the disclosed indexes length
             ..Default::default()
         };
-        assert!(!proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bls12_381, Fr, HashToG1Bls12381, Bls12381Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
     }
 }

--- a/src/tests/core_sign_tests.rs
+++ b/src/tests/core_sign_tests.rs
@@ -3,7 +3,7 @@ mod tests {
 
     use crate::constants::Bn254Const;
     use crate::key_gen::{PublicKey, SecretKey};
-    use crate::utils::interface_utilities::{create_generators, HashToCurveBn254};
+    use crate::utils::interface_utilities::{create_generators, HashToG1Bn254};
     use ark_bn254::{Bn254, Fr, G1Affine as G1};
     use rand::Rng;
     use test_case::test_case;
@@ -47,10 +47,10 @@ mod tests {
 
         // random messages: Vector of Fr
         let messages = generate_random_msg(count);
-        let generators = create_generators::<Bn254, HashToCurveBn254>(count+1, api_id);
+        let generators = create_generators::<Bn254, HashToG1Bn254>(count+1, api_id);
 
         let signature = sk.core_sign::<Bn254, Bn254Const>(generators.as_slice(), header, &messages, api_id).unwrap();
-        assert!(pk.core_verify::<Fr, Bn254Const, HashToCurveBn254>(signature, generators.as_slice(), header, &messages, api_id).unwrap());
+        assert!(pk.core_verify::<Fr, Bn254Const, HashToG1Bn254>(signature, generators.as_slice(), header, &messages, api_id).unwrap());
     }
 
     #[test]
@@ -64,34 +64,34 @@ mod tests {
 
         // random messages: Vector of Fr
         let messages = generate_random_msg(count);
-        let generators = create_generators::<Bn254, HashToCurveBn254>(count+1, api_id);
+        let generators = create_generators::<Bn254, HashToG1Bn254>(count+1, api_id);
 
         let signature = sk.core_sign::<Bn254, Bn254Const>(generators.as_slice(), header, &messages, api_id).unwrap();
 
         // valid signature verification
-        assert!(pk.core_verify::<Fr, Bn254Const, HashToCurveBn254>(signature, generators.as_slice(), header, &messages, api_id).unwrap());
+        assert!(pk.core_verify::<Fr, Bn254Const, HashToG1Bn254>(signature, generators.as_slice(), header, &messages, api_id).unwrap());
         
         // forged signature
         let mut forged_signature = signature.clone();
         forged_signature.a = G1::identity().into();
-        assert!(!pk.core_verify::<Fr, Bn254Const, HashToCurveBn254>(forged_signature, generators.as_slice(), header, &messages, api_id).unwrap());
+        assert!(!pk.core_verify::<Fr, Bn254Const, HashToG1Bn254>(forged_signature, generators.as_slice(), header, &messages, api_id).unwrap());
 
         // forged api_id
         let forged_api_id = b"abc";
-        assert!(!pk.core_verify::<Fr, Bn254Const, HashToCurveBn254>(signature, generators.as_slice(), header, &messages, forged_api_id).unwrap());
+        assert!(!pk.core_verify::<Fr, Bn254Const, HashToG1Bn254>(signature, generators.as_slice(), header, &messages, forged_api_id).unwrap());
 
         // forged header
         let forged_header = b"abc";
-        assert!(!pk.core_verify::<Fr, Bn254Const, HashToCurveBn254>(signature, generators.as_slice(), forged_header, &messages, api_id).unwrap());
+        assert!(!pk.core_verify::<Fr, Bn254Const, HashToG1Bn254>(signature, generators.as_slice(), forged_header, &messages, api_id).unwrap());
 
         // forged public key
         let forged_pk: PublicKey<Bn254> = PublicKey::<Bn254>::default();
-        assert!(!forged_pk.core_verify::<Fr, Bn254Const, HashToCurveBn254>(signature, generators.as_slice(), header, &messages, api_id).unwrap());
+        assert!(!forged_pk.core_verify::<Fr, Bn254Const, HashToG1Bn254>(signature, generators.as_slice(), header, &messages, api_id).unwrap());
 
         // forged messages
         let mut forged_messages = messages.clone();
         forged_messages[0] = Fr::from(0);
-        assert!(!pk.core_verify::<Fr, Bn254Const, HashToCurveBn254>(signature, generators.as_slice(), header, &forged_messages, api_id).unwrap());
+        assert!(!pk.core_verify::<Fr, Bn254Const, HashToG1Bn254>(signature, generators.as_slice(), header, &forged_messages, api_id).unwrap());
 
     }
 }

--- a/src/tests/core_sign_tests.rs
+++ b/src/tests/core_sign_tests.rs
@@ -1,13 +1,15 @@
 #[cfg(test)]
 mod tests {
-
-    use crate::constants::Bn254Const;
-    use crate::key_gen::{PublicKey, SecretKey};
-    use crate::utils::interface_utilities::{create_generators, HashToG1Bn254};
     use ark_bn254::{Bn254, Fr, G1Affine as G1};
     use rand::Rng;
     use test_case::test_case;
 
+    use crate::{
+        constants::Bn254Const,
+        key_gen::{PublicKey, SecretKey},
+        utils::interface_utilities::{create_generators, HashToG1Bn254},
+    };
+    
     fn generate_key() -> (SecretKey<Fr>, PublicKey<Bn254>){
 
         let mut key_material = [1u8; 32];

--- a/src/tests/proof_verify_tests.rs
+++ b/src/tests/proof_verify_tests.rs
@@ -33,8 +33,11 @@ mod tests {
         random_vecs
     }
 
+    // happy path
+    #[test_case(0, vec![], b"")]
     #[test_case(0, vec![], b"abc")]
     #[test_case(1, vec![0], b"abc")]
+    #[test_case(1, vec![], b"abc")]
     #[test_case(10, vec![0,1,2], b"")]
     #[test_case(10, vec![0,4,7,9], b"def")]
     #[test_case(5, vec![0,4], b"defghjsdjdbcjbejd")]

--- a/src/tests/proof_verify_tests.rs
+++ b/src/tests/proof_verify_tests.rs
@@ -1,19 +1,21 @@
 #[cfg(test)]
 mod tests {
 
-    use ark_bn254::{Fr, G1Affine as G1};
+    use ark_bn254::{Bn254, Fr, G1Affine as G1};
     use crate::key_gen::{PublicKey, SecretKey};
     use crate::proof_gen::{proof_gen, Proof};
     use crate::proof_verify::proof_verify;
+    use crate::constants::Bn254Const;
+    use crate::utils::interface_utilities::HashToCurveBn254;
     use test_case::test_case;
     use rand::Rng;
 
-    fn generate_key() -> (SecretKey, PublicKey){
+    fn generate_key() -> (SecretKey<Fr>, PublicKey<Bn254>){
 
         let mut key_material = [1u8; 32];
         let key_dst = b"BBS-SIG-KEYGEN-SALT-";
 
-        let sk = SecretKey::key_gen(&mut key_material, &[], key_dst.as_slice()).unwrap();
+        let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst.as_slice()).unwrap();
         let pk = SecretKey::sk_to_pk(&sk);
 
         (sk, pk)
@@ -49,13 +51,13 @@ mod tests {
 
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
-        let signature = sk.sign(&msg_slices, header).unwrap();
-        assert!(pk.verify(signature, header, &msg_slices).unwrap());
+        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, header).unwrap();
+        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
 
         let disclosed_msgs: Vec<&[u8]> = disclosed_indexes.iter().map(|i| msg_slices[*i]).collect();
 
-        let proof = proof_gen(pk.clone(), signature, header, &[], &msg_slices, disclosed_indexes.as_slice());
-        assert!(proof_verify(pk, proof.unwrap(), header, &[], disclosed_msgs.as_slice(), disclosed_indexes.as_slice()).unwrap());
+        let proof = proof_gen::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), signature, header, &[], &msg_slices, disclosed_indexes.as_slice());
+        assert!(proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk, proof.unwrap(), header, &[], disclosed_msgs.as_slice(), disclosed_indexes.as_slice()).unwrap());
     }
 
     #[test]
@@ -64,41 +66,41 @@ mod tests {
         let (sk, pk) = generate_key();
         let messages = generate_random_msg(10);
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
-        let signature = sk.sign(&msg_slices, b"").unwrap();
-        let proof = proof_gen(pk.clone(), signature, b"", &[], &msg_slices, &[0,1,5]).unwrap();
+        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, b"").unwrap();
+        let proof = proof_gen::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), signature, b"", &[], &msg_slices, &[0,1,5]).unwrap();
 
         // correct proof
-        assert!(proof_verify(pk.clone(), proof.clone(), b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), proof.clone(), b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
 
         // case 1
         // forged proof
         let mut forged_proof = proof.clone();
-        forged_proof.a_bar = G1::identity();
+        forged_proof.a_bar = G1::identity().into();
 
         // should fail because of forged a_bar
-        assert!(!proof_verify(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
         
         // case 2
         // default proof should fail
-        let forged_proof = Proof{
+        let forged_proof = Proof::<Bn254, Fr>{
             ..Default::default()
         };
 
         // result into error because of forged proof(commitment length is zero)
-        assert!(proof_verify(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).is_err());
+        assert!(proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).is_err());
 
         // case 3
         // forged public key
         let forged_pk = PublicKey{
             ..Default::default()
         };
-        assert!(!proof_verify(forged_pk, proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(forged_pk, proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
 
         // case 4
         let forged_proof = Proof{
             commitments: vec![Fr::from(0); 7],  // 10-3 where 3 is the disclosed indexes length
             ..Default::default()
         };
-        assert!(!proof_verify(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
     }
 }

--- a/src/tests/proof_verify_tests.rs
+++ b/src/tests/proof_verify_tests.rs
@@ -6,7 +6,7 @@ mod tests {
     use crate::proof_gen::{proof_gen, Proof};
     use crate::proof_verify::proof_verify;
     use crate::constants::Bn254Const;
-    use crate::utils::interface_utilities::HashToCurveBn254;
+    use crate::utils::interface_utilities::HashToG1Bn254;
     use test_case::test_case;
     use rand::Rng;
 
@@ -51,13 +51,13 @@ mod tests {
 
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
-        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, header).unwrap();
-        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
+        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(&msg_slices, header).unwrap();
+        assert!(pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, header, &msg_slices).unwrap());
 
         let disclosed_msgs: Vec<&[u8]> = disclosed_indexes.iter().map(|i| msg_slices[*i]).collect();
 
-        let proof = proof_gen::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), signature, header, &[], &msg_slices, disclosed_indexes.as_slice());
-        assert!(proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk, proof.unwrap(), header, &[], disclosed_msgs.as_slice(), disclosed_indexes.as_slice()).unwrap());
+        let proof = proof_gen::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), signature, header, &[], &msg_slices, disclosed_indexes.as_slice());
+        assert!(proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk, proof.unwrap(), header, &[], disclosed_msgs.as_slice(), disclosed_indexes.as_slice()).unwrap());
     }
 
     #[test]
@@ -66,11 +66,11 @@ mod tests {
         let (sk, pk) = generate_key();
         let messages = generate_random_msg(10);
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
-        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, b"").unwrap();
-        let proof = proof_gen::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), signature, b"", &[], &msg_slices, &[0,1,5]).unwrap();
+        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(&msg_slices, b"").unwrap();
+        let proof = proof_gen::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), signature, b"", &[], &msg_slices, &[0,1,5]).unwrap();
 
         // correct proof
-        assert!(proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), proof.clone(), b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), proof.clone(), b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
 
         // case 1
         // forged proof
@@ -78,7 +78,7 @@ mod tests {
         forged_proof.a_bar = G1::identity().into();
 
         // should fail because of forged a_bar
-        assert!(!proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
         
         // case 2
         // default proof should fail
@@ -87,20 +87,20 @@ mod tests {
         };
 
         // result into error because of forged proof(commitment length is zero)
-        assert!(proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).is_err());
+        assert!(proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).is_err());
 
         // case 3
         // forged public key
         let forged_pk = PublicKey{
             ..Default::default()
         };
-        assert!(!proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(forged_pk, proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(forged_pk, proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
 
         // case 4
         let forged_proof = Proof{
             commitments: vec![Fr::from(0); 7],  // 10-3 where 3 is the disclosed indexes length
             ..Default::default()
         };
-        assert!(!proof_verify::<Bn254, Fr, HashToCurveBn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
+        assert!(!proof_verify::<Bn254, Fr, HashToG1Bn254, Bn254Const>(pk.clone(), forged_proof, b"", &[], &[&msg_slices[0], &msg_slices[1], &msg_slices[5]], &[0,1,5]).unwrap());
     }
 }

--- a/src/tests/sign_verify_tests.rs
+++ b/src/tests/sign_verify_tests.rs
@@ -1,17 +1,18 @@
 #[cfg(test)]
 mod tests {
 
-    use crate::key_gen::{PublicKey, SecretKey};
-    use ark_bn254::G1Affine as G1;
+    use crate::{constants::Bn254Const, key_gen::{PublicKey, SecretKey}};
+    use ark_bn254::{Bn254, Fr, G1Affine as G1};
+    use crate::utils::interface_utilities::HashToCurveBn254;
     use rand::Rng;
     use test_case::test_case;
 
-    fn generate_key() -> (SecretKey, PublicKey){
+    fn generate_key() -> (SecretKey<Fr>, PublicKey<Bn254>){
 
         let mut key_material: [u8; 32] = rand::random();
         let key_dst = b"BBS-SIG-KEYGEN-SALT-";
 
-        let sk = SecretKey::key_gen(&mut key_material, &[], key_dst.as_slice()).unwrap();
+        let sk = SecretKey::<Fr>::key_gen::<Bn254>(&mut key_material, &[], key_dst.as_slice()).unwrap();
         let pk = SecretKey::sk_to_pk(&sk);
 
         (sk, pk)
@@ -46,8 +47,8 @@ mod tests {
 
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
-        let signature = sk.sign(&msg_slices, header).unwrap();
-        assert!(pk.verify(signature, header, &msg_slices).unwrap());
+        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, header).unwrap();
+        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
     }
 
     #[test]
@@ -62,28 +63,28 @@ mod tests {
         let messages = generate_random_msg(count);
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
-        let signature = sk.sign(&msg_slices, header).unwrap();
+        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, header).unwrap();
 
         // valid signature verification
-        assert!(pk.verify(signature, header, &msg_slices).unwrap());
+        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
         
         // forged signature
         let mut forged_signature = signature.clone();
-        forged_signature.a = G1::identity();
-        assert!(!pk.verify(forged_signature, header, &msg_slices).unwrap());
+        forged_signature.a = G1::identity().into();
+        assert!(!pk.verify::<Fr, HashToCurveBn254, Bn254Const>(forged_signature, header, &msg_slices).unwrap());
 
         // forged header
         let forged_header = b"abc";
-        assert!(!pk.verify(signature, forged_header, &msg_slices).unwrap());
+        assert!(!pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, forged_header, &msg_slices).unwrap());
 
         // forged public key
         let forged_pk = PublicKey::default();
-        assert!(!forged_pk.verify(signature, header, &msg_slices).unwrap());
+        assert!(!forged_pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
 
         // forged messages
         let mut forged_messages = msg_slices.clone();
         forged_messages[0] = &[0,1];
-        assert!(!pk.verify(signature, header, &forged_messages).unwrap());
+        assert!(!pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &forged_messages).unwrap());
 
     }
 }

--- a/src/tests/sign_verify_tests.rs
+++ b/src/tests/sign_verify_tests.rs
@@ -1,11 +1,14 @@
 #[cfg(test)]
 mod tests {
-
-    use crate::{constants::Bn254Const, key_gen::{PublicKey, SecretKey}};
     use ark_bn254::{Bn254, Fr, G1Affine as G1};
-    use crate::utils::interface_utilities::HashToG1Bn254;
     use rand::Rng;
     use test_case::test_case;
+
+    use crate::{
+        constants::Bn254Const, 
+        key_gen::{PublicKey, SecretKey},
+        utils::interface_utilities::HashToG1Bn254,
+    };    
 
     fn generate_key() -> (SecretKey<Fr>, PublicKey<Bn254>){
 

--- a/src/tests/sign_verify_tests.rs
+++ b/src/tests/sign_verify_tests.rs
@@ -3,7 +3,7 @@ mod tests {
 
     use crate::{constants::Bn254Const, key_gen::{PublicKey, SecretKey}};
     use ark_bn254::{Bn254, Fr, G1Affine as G1};
-    use crate::utils::interface_utilities::HashToCurveBn254;
+    use crate::utils::interface_utilities::HashToG1Bn254;
     use rand::Rng;
     use test_case::test_case;
 
@@ -47,8 +47,8 @@ mod tests {
 
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
-        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, header).unwrap();
-        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
+        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(&msg_slices, header).unwrap();
+        assert!(pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, header, &msg_slices).unwrap());
     }
 
     #[test]
@@ -63,28 +63,28 @@ mod tests {
         let messages = generate_random_msg(count);
         let msg_slices: Vec<&[u8]> = messages.iter().map(|v| v.as_slice()).collect();
 
-        let signature = sk.sign::<Bn254, Bn254Const, HashToCurveBn254>(&msg_slices, header).unwrap();
+        let signature = sk.sign::<Bn254, Bn254Const, HashToG1Bn254>(&msg_slices, header).unwrap();
 
         // valid signature verification
-        assert!(pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
+        assert!(pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, header, &msg_slices).unwrap());
         
         // forged signature
         let mut forged_signature = signature.clone();
         forged_signature.a = G1::identity().into();
-        assert!(!pk.verify::<Fr, HashToCurveBn254, Bn254Const>(forged_signature, header, &msg_slices).unwrap());
+        assert!(!pk.verify::<Fr, HashToG1Bn254, Bn254Const>(forged_signature, header, &msg_slices).unwrap());
 
         // forged header
         let forged_header = b"abc";
-        assert!(!pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, forged_header, &msg_slices).unwrap());
+        assert!(!pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, forged_header, &msg_slices).unwrap());
 
         // forged public key
         let forged_pk = PublicKey::default();
-        assert!(!forged_pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &msg_slices).unwrap());
+        assert!(!forged_pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, header, &msg_slices).unwrap());
 
         // forged messages
         let mut forged_messages = msg_slices.clone();
         forged_messages[0] = &[0,1];
-        assert!(!pk.verify::<Fr, HashToCurveBn254, Bn254Const>(signature, header, &forged_messages).unwrap());
+        assert!(!pk.verify::<Fr, HashToG1Bn254, Bn254Const>(signature, header, &forged_messages).unwrap());
 
     }
 }

--- a/src/utils/core_utilities.rs
+++ b/src/utils/core_utilities.rs
@@ -1,14 +1,17 @@
-use std::usize;
 use ark_ec::pairing::Pairing;
 use ark_ff::Field;
 use ark_serialize::CanonicalSerialize;
 
-use crate::utils::utilities_helper;
-use crate::utils::utilities_helper::expand_message;
-use crate::key_gen::PublicKey;
+use crate::{
+    utils::utilities_helper::{ expand_message, FromOkm},
+    key_gen::PublicKey
+};
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-hash-to-scalar
-pub fn hash_to_scalar<const L: usize, F: Field + utilities_helper::FromOkm<L, F>>(msg: &[u8], dst: &[u8]) -> F {
+pub fn hash_to_scalar<const L: usize, F>(msg: &[u8], dst: &[u8]) -> F 
+where 
+    F: Field + FromOkm<L, F>,
+{
 
     // expand_len aka len_in_bytes = 48: Must be defined to be at least ceil((ceil(log2(r))+k)/8), where log2(r) and k are defined by each ciphersuite 
     // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-additional-parameters
@@ -20,11 +23,10 @@ pub fn hash_to_scalar<const L: usize, F: Field + utilities_helper::FromOkm<L, F>
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-domain-calculation
 pub fn calculate_domain<E, F, const L: usize> (pk: &PublicKey<E>, q_1: E::G1, h_points: &[E::G1], header: &[u8], api_id: &[u8]) -> F 
-
 where 
     E: Pairing,
-    F: Field + utilities_helper::FromOkm<L, F>,
-    {
+    F: Field + FromOkm<L, F>,
+{
     
     let l = h_points.len();
     let mut dom_octs = Vec::new();
@@ -63,7 +65,10 @@ fn get_random(len: usize) -> Vec<u8> {
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-random-scalars
-pub fn calculate_random_scalars<const L: usize, F: Field + utilities_helper::FromOkm<L, F>>(count: usize) -> Vec<F> {
+pub fn calculate_random_scalars<const L: usize, F>(count: usize) -> Vec<F> 
+where 
+    F: Field + FromOkm<L, F>
+{
     let mut result = Vec::with_capacity(count);
 
     for _ in 0..count {

--- a/src/utils/core_utilities.rs
+++ b/src/utils/core_utilities.rs
@@ -1,22 +1,30 @@
-use ark_bn254::{Fr, G1Affine as G1};
+use std::usize;
+use ark_ec::pairing::Pairing;
+use ark_ff::Field;
 use ark_serialize::CanonicalSerialize;
 
-use super::utilities_helper::{ expand_message, FromOkm};
+use crate::utils::utilities_helper;
+use crate::utils::utilities_helper::expand_message;
 use crate::key_gen::PublicKey;
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-hash-to-scalar
-pub fn hash_to_scalar(msg: &[u8], dst: &[u8]) -> Fr {
+pub fn hash_to_scalar<const L: usize, F: Field + utilities_helper::FromOkm<L, F>>(msg: &[u8], dst: &[u8]) -> F {
 
     // expand_len aka len_in_bytes = 48: Must be defined to be at least ceil((ceil(log2(r))+k)/8), where log2(r) and k are defined by each ciphersuite 
     // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-additional-parameters
-    let uniform_bytes = expand_message(msg, dst, 48);
+    let uniform_bytes = expand_message(msg, dst, L);
     
-    let data: &[u8; 192] = &uniform_bytes[..].try_into().unwrap();
-    Fr::from_okm(data)
+    let data: &[u8; L] = &uniform_bytes[..L].try_into().unwrap();
+    F::from_okm(data)
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-domain-calculation
-pub fn calculate_domain(pk: &PublicKey, q_1: G1, h_points: &[G1], header: &[u8], api_id: &[u8]) -> Fr {
+pub fn calculate_domain<E, F, const L: usize> (pk: &PublicKey<E>, q_1: E::G1, h_points: &[E::G1], header: &[u8], api_id: &[u8]) -> F 
+
+where 
+    E: Pairing,
+    F: Field + utilities_helper::FromOkm<L, F>,
+    {
     
     let l = h_points.len();
     let mut dom_octs = Vec::new();
@@ -46,7 +54,7 @@ pub fn calculate_domain(pk: &PublicKey, q_1: G1, h_points: &[G1], header: &[u8],
 
     let hash_to_scalar_dst = [api_id, b"H2S_"].concat();
 
-    hash_to_scalar(&dom_input, &hash_to_scalar_dst)
+    hash_to_scalar::<L, F>(&dom_input, &hash_to_scalar_dst)
 
 }
 
@@ -55,12 +63,12 @@ fn get_random(len: usize) -> Vec<u8> {
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-random-scalars
-pub fn calculate_random_scalars(count: usize) -> Vec<Fr> {
+pub fn calculate_random_scalars<const L: usize, F: Field + utilities_helper::FromOkm<L, F>>(count: usize) -> Vec<F> {
     let mut result = Vec::with_capacity(count);
 
     for _ in 0..count {
-        let data: &[u8; 48] = &get_random(48)[..].try_into().unwrap();
-        result.push(Fr::from_okm(data));
+        let data: &[u8; L] = &get_random(L)[..].try_into().unwrap();
+        result.push(F::from_okm(data));
     }
     result
 }

--- a/src/utils/interface_utilities.rs
+++ b/src/utils/interface_utilities.rs
@@ -1,8 +1,11 @@
-use ark_bn254::{G1Affine as G1, Fr};
+use ark_bn254::G1Affine as G1;
+use ark_ff::Field;
 use bn254_hash2curve::hash2g1::HashToG1;
+use ark_ec::pairing::Pairing;
 
 use super::utilities_helper::expand_message;
 use super::core_utilities::hash_to_scalar;
+use crate::utils::utilities_helper;
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#section-4.1.1
 pub fn create_generators(count: usize, api_id: &[u8]) -> Vec<G1> {
@@ -32,7 +35,11 @@ pub fn create_generators(count: usize, api_id: &[u8]) -> Vec<G1> {
 }
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-messages-to-scalars
-pub fn msg_to_scalars(messages: &[&[u8]] , api_id: &[u8]) -> Vec<Fr> {
+pub fn msg_to_scalars<E, F, const L: usize>(messages: &[&[u8]] , api_id: &[u8]) -> Vec<F> 
+where 
+    E: Pairing,
+    F: Field + utilities_helper::FromOkm<L, F>, 
+{
     let mut msg_scalars = Vec::new();
     for &msg in messages {
         msg_scalars.push(hash_to_scalar(msg, api_id));

--- a/src/utils/interface_utilities.rs
+++ b/src/utils/interface_utilities.rs
@@ -1,4 +1,3 @@
-use ark_bn254::G1Affine as G1;
 use ark_ff::Field;
 use bn254_hash2curve::hash2g1::HashToG1;
 use ark_ec::pairing::Pairing;
@@ -6,15 +5,39 @@ use ark_ec::pairing::Pairing;
 use super::utilities_helper::expand_message;
 use super::core_utilities::hash_to_scalar;
 use crate::utils::utilities_helper;
+use ark_bls12_381::G1Affine as G1Bls12_381;
+
+pub trait HashToG1<E: Pairing> {
+    fn hash_to_g1(msg: &[u8], dst: &[u8]) -> E::G1;
+}
+
+pub struct HashToCurveBn254;
+pub struct HashToCurveBls12381;
+
+impl <E: Pairing<G1 = ark_ec::short_weierstrass::Projective<ark_bn254::g1::Config>>>HashToG1<E> for HashToCurveBn254 {
+
+    fn hash_to_g1(message: &[u8], dst: &[u8]) -> E::G1 {
+        HashToG1(message, dst).into()
+    }
+}
+
+impl <E: Pairing<G1 = ark_ec::short_weierstrass::Projective<ark_bls12_381::g1::Config>>>HashToG1<E> for HashToCurveBls12381 {
+
+    fn hash_to_g1(_message: &[u8], _dst: &[u8]) -> E::G1 {
+
+        //TODO: Implement this
+        G1Bls12_381::identity().into()
+    }
+}
 
 // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#section-4.1.1
-pub fn create_generators(count: usize, api_id: &[u8]) -> Vec<G1> {
+pub fn create_generators<E: Pairing, H: HashToG1<E>>(count: usize, api_id: &[u8]) -> Vec<E::G1> {
 
     let seed_dst = [api_id, b"SIG_GENERATOR_SEED_"].concat();
     let generator_dst = [api_id, b"SIG_GENERATOR_DST_"].concat();
     let generator_seed = [api_id, b"MESSAGE_GENERATOR_SEED"].concat();
 
-    let mut generators: Vec<G1> = Vec::new();
+    let mut generators: Vec<E::G1> = Vec::new();
 
     // expand_len aka len_in_bytes = 48: Must be defined to be at least ceil((ceil(log2(r))+k)/8), where log2(r) and k are defined by each ciphersuite 
     // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-additional-parameters
@@ -28,7 +51,7 @@ pub fn create_generators(count: usize, api_id: &[u8]) -> Vec<G1> {
 
         v = expand_message(&msg, seed_dst.as_slice(), 48);
 
-        generators.push(HashToG1(v.as_slice(), generator_dst.as_slice()));
+        generators.push(H::hash_to_g1(v.as_slice(), generator_dst.as_slice()));
     }
 
     generators

--- a/src/utils/utilities_helper.rs
+++ b/src/utils/utilities_helper.rs
@@ -1,13 +1,14 @@
-use std::usize;
-use ark_bn254::fr::Fr;
+use ark_bn254::Fr;
 use ark_ff::Field;
 use num_bigint::BigUint;
-use digest::generic_array::GenericArray;
 use num_integer::Integer;
-use digest::generic_array::typenum::U32;
-pub use sha2::{Sha256, digest::Digest};
+use sha2::{Sha256, digest::Digest};
 use subtle::{Choice, ConditionallySelectable};
 use ark_bls12_381::Fr as FrBls12_381;
+use digest::generic_array::{
+    GenericArray, 
+    typenum::U32
+};
 
 pub trait FromOkm<const L: usize, F: Field>: Sized {
     /// Convert a byte sequence into a scalar

--- a/src/utils/utilities_helper.rs
+++ b/src/utils/utilities_helper.rs
@@ -1,18 +1,20 @@
 use std::usize;
-use ark_bn254::{fr::Fr, fq::Fq};
+use ark_bn254::fr::Fr;
+use ark_ff::Field;
 use num_bigint::BigUint;
 use digest::generic_array::GenericArray;
 use num_integer::Integer;
 use digest::generic_array::typenum::U32;
 pub use sha2::{Sha256, digest::Digest};
 use subtle::{Choice, ConditionallySelectable};
+use ark_bls12_381::Fr as FrBls12_381;
 
-pub trait FromOkm<const L: usize>: Sized {
+pub trait FromOkm<const L: usize, F: Field>: Sized {
     /// Convert a byte sequence into a scalar
     fn from_okm(data: &[u8; L]) -> Self;
 }
 
-impl<const L: usize> FromOkm<L> for Fr {
+impl<const L: usize, F: Field> FromOkm<L, F> for Fr {
     fn from_okm(data: &[u8; L]) -> Self {
         let p = BigUint::from_bytes_be(
             &hex::decode("30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000001")
@@ -26,17 +28,18 @@ impl<const L: usize> FromOkm<L> for Fr {
     }
 }
 
-impl<const L: usize> FromOkm<L> for Fq {
+//TODO: Check
+impl<const L: usize, F: Field> FromOkm<L, F> for FrBls12_381 {
     fn from_okm(data: &[u8; L]) -> Self {
         let p = BigUint::from_bytes_be(
-            &hex::decode("30644E72E131A029B85045B68181585D97816A916871CA8D3C208C16D87CFD47")
+            &hex::decode("73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001")
                 .unwrap(),
         );
 
         let mut x = BigUint::from_bytes_be(&data[..]);
             x = x.mod_floor(&p);
 
-            Fq::from(x)
+            FrBls12_381::from(x)
     }
 }
 

--- a/src/utils/utilities_helper.rs
+++ b/src/utils/utilities_helper.rs
@@ -1,5 +1,5 @@
 use ark_bn254::Fr;
-use ark_ff::Field;
+use ark_ff::{Field, PrimeField, BigInt};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use sha2::{Sha256, digest::Digest};
@@ -29,18 +29,30 @@ impl<const L: usize, F: Field> FromOkm<L, F> for Fr {
     }
 }
 
-//TODO: Check
+#[allow(non_snake_case)]
 impl<const L: usize, F: Field> FromOkm<L, F> for FrBls12_381 {
     fn from_okm(data: &[u8; L]) -> Self {
-        let p = BigUint::from_bytes_be(
-            &hex::decode("73EDA753299D7D483339D80809A1D80553BDA402FFFE5BFEFFFFFFFF00000001")
-                .unwrap(),
-        );
 
-        let mut x = BigUint::from_bytes_be(&data[..]);
-            x = x.mod_floor(&p);
+        const F_2_192_BIG_INT: BigInt<4> = BigInt::new([
+            0x59476ebc41b4528fu64,
+            0xc5a30cb243fcc152u64,
+            0x2b34e63940ccbd72u64,
+            0x1e179025ca247088u64,
+        ]);
 
-            FrBls12_381::from(x)
+        let F_2_192 = FrBls12_381::new(F_2_192_BIG_INT);
+        
+        let mut elm_array = [0u8; 32];
+        elm_array[8..].copy_from_slice(data[0..24].as_ref());
+
+        let mut elm = FrBls12_381::from_be_bytes_mod_order(&elm_array);
+        elm = elm * F_2_192;
+        
+        let mut elm_array = [0u8; 32];
+        elm_array[8..].copy_from_slice(data[24..48].as_ref());
+        let elm2 = FrBls12_381::from_be_bytes_mod_order(&elm_array);
+
+        elm + elm2
     }
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,42 +1,57 @@
-use ark_bn254::{ G1Affine as G1, Fr, G1Projective, Fq12, Bn254};
-use ark_ec::{ pairing::Pairing, AffineRepr};
+use ark_ec::pairing::Pairing;
 use ark_ff::fields::Field;
 
 use crate::key_gen::PublicKey;
 use crate::sign::{SignatureError, Signature};
 use crate::utils::core_utilities::calculate_domain;
-use crate::constants::{P1, BP2, CIPHERSUITE_ID};
-use crate::utils::interface_utilities::msg_to_scalars;
+use crate::constants::{Constants, CIPHERSUITE_ID};
+use crate::utils::interface_utilities::{msg_to_scalars, HashToG1};
 use crate::utils::interface_utilities::create_generators;
+use crate::utils::utilities_helper;
+use elliptic_curve::ops::Mul;
 
-impl PublicKey {
+impl <E: Pairing>PublicKey<E> {
 
     // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-signature-verification-veri
-    pub fn verify(&self, signature: Signature, header: &[u8], messages: &[&[u8]]) -> Result<bool, SignatureError> {
+    pub fn verify<F: Field+ utilities_helper::FromOkm<48, F>, H: HashToG1<E>, C: Constants<E>,>(&self, signature: Signature<E, F>, header: &[u8], messages: &[&[u8]]) -> Result<bool, SignatureError> 
+    
+    where 
+    E: Pairing,
+    E::G2: Mul<F, Output = E::G2>,
+    E::G1: Mul<F, Output = E::G1>,
+    // E::TargetField: Mul<Fq12, Output = E::TargetField>,
+
+    {
         
         let api_id = [CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
-        let message_scalars = msg_to_scalars(messages, &api_id);
-        let generators = create_generators(messages.len() + 1, &api_id);
+        let message_scalars = msg_to_scalars::<E, F, 48>(messages, &api_id);
+        let generators = create_generators::<E, H>(messages.len() + 1, &api_id);
 
-        self.core_verify(signature, generators.as_slice(), header, &message_scalars, &api_id)
+        self.core_verify::<F, C, H>(signature, generators.as_slice(), header, &message_scalars, &api_id)
     }
     
     // https://identity.foundation/bbs-signature/draft-irtf-cfrg-bbs-signatures.html#name-coreverify
-    pub(crate) fn core_verify(&self, signature: Signature, generators: &[G1], header: &[u8], messages: &[Fr], api_id: &[u8]) -> Result<bool, SignatureError> {
+    pub(crate) fn core_verify<F: Field+ utilities_helper::FromOkm<48, F>, C: Constants<E>, H: HashToG1<E>>(&self, signature: Signature<E, F>, generators: &[E::G1], header: &[u8], messages: &[F], api_id: &[u8]) -> Result<bool, SignatureError> 
+    
+    where 
+    E: Pairing,
+    E::G2: Mul<F, Output = E::G2>,
+    E::G1: Mul<F, Output = E::G1>,
+    {
         
         if messages.len() + 1 != generators.len() {
             return Err(SignatureError::InvalidMessageAndGeneratorsLength);
         }
 
-        let domain = calculate_domain(self, generators[0], &generators[1..], header, api_id);
+        let domain = calculate_domain::<E, F, 48>(self, generators[0], &generators[1..], header, api_id);
 
-        let mut b: G1Projective = P1.into_group();
+        let mut b: E::G1 = C::bp1();
         b = b + generators[0] * domain;
 
         for i in 1..generators.len() {
             b = b + generators[i] * messages[i - 1];
         }
-
-        Ok(Bn254::pairing(signature.a, self.pk + BP2.into_group() * signature.e).0 * Bn254::pairing(b, -BP2.into_group()).0 == Fq12::ONE)
+        
+        Ok(E::pairing(signature.a, self.pk + C::bp2() * signature.e).0 * E::pairing(b, -C::bp2()).0 == E::TargetField::ONE)
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4,10 +4,7 @@ use elliptic_curve::ops::Mul;
 
 use crate::{
     key_gen::PublicKey,
-    constants::{
-        CIPHERSUITE_ID, 
-        Constants
-    },
+    constants::Constants,
     sign::{
         Signature,
         SignatureError,
@@ -26,12 +23,12 @@ impl <E: Pairing>PublicKey<E> {
     where 
         F: Field+ FromOkm<48, F>,
         H: HashToG1<E>,
-        C: Constants<E>,
+        C: for<'a> Constants<'a, E>,
         E::G2: Mul<F, Output = E::G2>,
         E::G1: Mul<F, Output = E::G1>,
     {
         
-        let api_id = [CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
+        let api_id = [C::CIPHERSUITE_ID, b"H2G_HM2S_"].concat();
         let message_scalars = msg_to_scalars::<E, F, 48>(messages, &api_id);
         let generators = create_generators::<E, H>(messages.len() + 1, &api_id);
 
@@ -42,7 +39,7 @@ impl <E: Pairing>PublicKey<E> {
     pub(crate) fn core_verify<F, C, H>(&self, signature: Signature<E, F>, generators: &[E::G1], header: &[u8], messages: &[F], api_id: &[u8]) -> Result<bool, SignatureError> 
     where 
         F: Field+ FromOkm<48, F>,
-        C: Constants<E>, 
+        C: for<'a> Constants<'a, E>,
         H: HashToG1<E>,
         E::G2: Mul<F, Output = E::G2>,
         E::G1: Mul<F, Output = E::G1>,


### PR DESCRIPTION
This PR includes the following:

- Modifies the earlier BBS+ implementation over BN254 to more generic implementation to support both BN254 and BLS12-381 pairing friendly curves.
- All the core functions and utility functions along with tests and benchmark is modified accordingly.
- The implementation relies on arkworks elliptic curves and field traits hence, both the curves supported are of arkworks.
- By implementing `HashToG1` and `Constants` traits defined here, this implementation can support any pairing friendly curve of arkworks.